### PR TITLE
Fix the bug of mold piercing when using cuda.

### DIFF
--- a/source/leisaac/leisaac/assets/robots/lerobot.py
+++ b/source/leisaac/leisaac/assets/robots/lerobot.py
@@ -38,7 +38,7 @@ SO101_FOLLOWER_CFG = ArticulationCfg(
     actuators={
         "sts3215": ImplicitActuatorCfg(
             joint_names_expr=[".*"],
-            effort_limit_sim=10,
+            effort_limit_sim=1,
             velocity_limit_sim=10,
             stiffness=17.8,
             damping=0.60,


### PR DESCRIPTION
When using cuda, picking up objects does not pass through the mold, but the cpu still has this problem.