### PR TITLE
mimicgen support lift cube task example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ assets/scenes/*
 !assets/scenes/.gitkeep
 assets/robots/*
 !assets/robots/.gitkeep
+
+# greenscreen
+greenscreen/*

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ python scripts/environments/teleoperation/replay.py \
     --device=cpu \
     --enable_cameras \
     --dataset_file=./datasets/dataset.hdf5 \
-    --episode_index=0
+    --select_episodes 1 2
 ```
 
 <details>
@@ -183,7 +183,7 @@ python scripts/environments/teleoperation/replay.py \
 
 - `--dataset_file`: Path to the recorded dataset, e.g., `./datasets/record_data.hdf5`.
 
-- `--episode_index`: Index of the episode to replay from the dataset, e.g., `0`.
+- `--select_episodes`: A list of episode indices to replayed, Keep empty to replay all episodes.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo apt install cmake build-essential
 
 cd IsaacLab
 # fix isaaclab version for isaacsim4.5
-git checkout v2.1.0
+git checkout v2.1.1
 ./isaaclab.sh --install
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ python scripts/environments/teleoperation/replay.py \
     --num_envs=1 \
     --device=cpu \
     --enable_cameras \
+    --replay_mode=action \
     --dataset_file=./datasets/dataset.hdf5 \
     --select_episodes 1 2
 ```
@@ -180,6 +181,8 @@ python scripts/environments/teleoperation/replay.py \
 - `--device`: Specify the computation device, such as `cpu` or `cuda` (GPU).
 
 - `--enable_cameras`: Enable camera sensors to visualize when replay.
+
+- `--replay_mode`: Replay mode, we support replay `action` or `state`.
 
 - `--dataset_file`: Path to the recorded dataset, e.g., `./datasets/record_data.hdf5`.
 

--- a/scripts/environments/teleoperation/replay.py
+++ b/scripts/environments/teleoperation/replay.py
@@ -157,7 +157,7 @@ def main():
                             env_episode_data_map[env_id] = episode_data
                             # Set initial state for the new episode
                             initial_state = episode_data.get_initial_state()
-                            env.reset_to(initial_state, torch.tensor([env_id], device=env.device), seed=int(episode_data.seed), is_relative=True)
+                            env.reset_to(initial_state, torch.tensor([env_id], device=env.device), seed=int(episode_data.seed) if episode_data.seed is not None else None, is_relative=True)
                             # Get the first action for the new episode
                             env_next_action = get_next_action(env_episode_data_map[env_id], return_state=args_cli.replay_mode == "state", task_type=task_type)
                             has_next_action = True

--- a/scripts/environments/teleoperation/replay.py
+++ b/scripts/environments/teleoperation/replay.py
@@ -14,7 +14,7 @@ parser.add_argument("--task", type=str, default=None, help="Name of the task.")
 parser.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate.")
 parser.add_argument("--step_hz", type=int, default=60, help="Environment stepping rate in Hz.")
 parser.add_argument("--dataset_file", type=str, default="./datasets/dataset.hdf5", help="File path to load recorded demos.")
-parser.add_argument("--episode_index", type=int, default=0, help="Replay the episode with the given index.")
+parser.add_argument("--select_episodes", type=int, nargs="+", default=[], help="A list of episode indices to replayed. Keep empty to replay all episodes.")
 
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
@@ -27,14 +27,15 @@ app_launcher_args = vars(args_cli)
 app_launcher = AppLauncher(app_launcher_args)
 simulation_app = app_launcher.app
 
+import os
 import time
 import torch
-import h5py
-import numpy as np
 import gymnasium as gym
+import contextlib
 
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab_tasks.utils import parse_env_cfg
+from isaaclab.utils.datasets import HDF5DatasetFileHandler, EpisodeData
 
 import leisaac  # noqa: F401
 from leisaac.utils.env_utils import get_task_type
@@ -68,75 +69,109 @@ class RateLimiter:
                 self.last_time += self.sleep_duration
 
 
-def parse_dataset(dataset_file: str, episode_index: int, task_type: str, device: str):
-    with h5py.File(dataset_file, 'r') as f:
-        demo_names = list(f['data'].keys())
-        demo_name = demo_names[episode_index]
-        demo_group = f['data'][demo_name]
-
-        seed = int(demo_group.attrs.get("seed", -1))
-
+def get_next_action(episode_data: EpisodeData, return_state: bool = False, task_type: str = None):
+    if return_state:
+        next_state = episode_data.get_next_state()
+        if next_state is None:
+            return None
         if task_type == "bi-so101leader":
-            left_joint_pos = torch.tensor(np.array(demo_group['obs/left_joint_pos']), device=device)
-            right_joint_pos = torch.tensor(np.array(demo_group['obs/right_joint_pos']), device=device)
-            states = torch.cat([left_joint_pos, right_joint_pos], dim=1)
+            left_joint_pos = next_state['articulation']['left_arm']['joint_position']
+            right_joint_pos = next_state['articulation']['right_arm']['joint_position']
+            return torch.cat([left_joint_pos, right_joint_pos], dim=0)
         else:
-            states = torch.tensor(np.array(demo_group['obs/joint_pos']), device=device)
-
-        init_object_state = {}
-        for key in list(demo_group['initial_state/rigid_object'].keys()):
-            root_state = torch.tensor(demo_group[f'initial_state/rigid_object/{key}/root_pose'], device=device)
-            root_velocity = torch.tensor(demo_group[f'initial_state/rigid_object/{key}/root_velocity'], device=device)
-            init_object_state[key] = torch.cat([root_state, root_velocity], dim=1)
-
-        return states, init_object_state, seed
-
-
-def reset_object_state(env: ManagerBasedRLEnv, init_object_state: dict):
-    for key, root_state in init_object_state.items():
-        env.scene[key].write_root_state_to_sim(root_state)
+            return next_state['articulation']['robot']['joint_position']
+    else:
+        return episode_data.get_next_action()
 
 
 def main():
-    """Running lerobot teleoperation with leisaac manipulation environment."""
+    """Replay episodes loaded from a file."""
 
-    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
+    # Load dataset
+    if not os.path.exists(args_cli.dataset_file):
+        raise FileNotFoundError(f"The dataset file {args_cli.dataset_file} does not exist.")
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.open(args_cli.dataset_file)
+    episode_count = dataset_file_handler.get_num_episodes()
+
+    if episode_count == 0:
+        print("No episodes found in the dataset.")
+        exit()
+
+    episode_indices_to_replay = args_cli.select_episodes
+    if len(episode_indices_to_replay) == 0:
+        episode_indices_to_replay = list(range(episode_count))
+
+    num_envs = args_cli.num_envs
+
+    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=num_envs)
     task_type = get_task_type(args_cli.task)
     env_cfg.use_teleop_device(task_type)
 
-    # modify configuration
-    if hasattr(env_cfg.terminations, "time_out"):
-        env_cfg.terminations.time_out = None
-    if hasattr(env_cfg.terminations, "success"):
-        env_cfg.terminations.success = None
-    env_cfg.recorders = None
+    # Disable all recorders and terminations
+    env_cfg.recorders = {}
+    env_cfg.terminations = {}
 
-    # create environment
+    # create environment from loaded config
     env: ManagerBasedRLEnv = gym.make(args_cli.task, cfg=env_cfg).unwrapped
+
+    # Get idle action (idle actions are applied to envs without next action)
+    if hasattr(env_cfg, "idle_action"):
+        idle_action = env_cfg.idle_action.repeat(num_envs, 1)
+    else:
+        idle_action = torch.zeros(env.action_space.shape)
+
+    # reset before starting
+    env.reset()
 
     rate_limiter = RateLimiter(args_cli.step_hz)
 
-    states, init_object_state, seed = parse_dataset(args_cli.dataset_file, args_cli.episode_index, task_type, args_cli.device)
+    # simulate environment -- run everything in inference mode
+    episode_names = list(dataset_file_handler.get_episode_names())
+    replayed_episode_count = 0
+    with contextlib.suppress(KeyboardInterrupt) and torch.inference_mode():
+        while simulation_app.is_running() and not simulation_app.is_exiting():
+            env_episode_data_map = {index: EpisodeData() for index in range(num_envs)}
+            has_next_action = True
+            while has_next_action:
+                # initialize actions with idle action so those without next action will not move
+                actions = idle_action
+                has_next_action = False
+                for env_id in range(num_envs):
+                    env_next_action = get_next_action(env_episode_data_map[env_id], return_state=True, task_type=task_type)
+                    if env_next_action is None:
+                        next_episode_index = None
+                        while episode_indices_to_replay:
+                            next_episode_index = episode_indices_to_replay.pop(0)
+                            if next_episode_index < episode_count:
+                                break
+                            next_episode_index = None
 
-    # reset environment
-    env.seed(seed)
-    env.reset()
-    reset_object_state(env, init_object_state)
-
-    # simulate environment
-    while simulation_app.is_running():
-        # run everything in inference mode
-        with torch.inference_mode():
-            for state in states:
-                env.step(state.unsqueeze(0))
-                if rate_limiter:
-                    rate_limiter.sleep(env)
-            env.reset()
-            reset_object_state(env, init_object_state)
-
-    # close the simulator
+                        if next_episode_index is not None:
+                            replayed_episode_count += 1
+                            print(f"{replayed_episode_count :4}: Loading #{next_episode_index} episode to env_{env_id}")
+                            episode_data = dataset_file_handler.load_episode(
+                                episode_names[next_episode_index], env.device
+                            )
+                            env_episode_data_map[env_id] = episode_data
+                            # Set initial state for the new episode
+                            initial_state = episode_data.get_initial_state()
+                            env.reset_to(initial_state, torch.tensor([env_id], device=env.device), seed=int(episode_data.seed), is_relative=True)
+                            # Get the first action for the new episode
+                            env_next_action = get_next_action(env_episode_data_map[env_id], return_state=True, task_type=task_type)
+                            has_next_action = True
+                        else:
+                            continue
+                    else:
+                        has_next_action = True
+                    actions[env_id] = env_next_action
+                env.step(actions)
+                rate_limiter.sleep(env)
+            break
+    # Close environment after replay in complete
+    plural_trailing_s = "s" if replayed_episode_count > 1 else ""
+    print(f"Finished replaying {replayed_episode_count} episode{plural_trailing_s}.")
     env.close()
-    simulation_app.close()
 
 
 if __name__ == "__main__":

--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -21,7 +21,7 @@ parser.add_argument("--port", type=str, default='/dev/ttyACM0', help="Port for t
 parser.add_argument("--left_arm_port", type=str, default='/dev/ttyACM0', help="Port for the left teleop device:bi-so101leader, default is /dev/ttyACM0")
 parser.add_argument("--right_arm_port", type=str, default='/dev/ttyACM1', help="Port for the right teleop device:bi-so101leader, default is /dev/ttyACM1")
 parser.add_argument("--task", type=str, default=None, help="Name of the task.")
-parser.add_argument("--seed", type=int, default=42, help="Seed for the environment.")
+parser.add_argument("--seed", type=int, default=None, help="Seed for the environment.")
 parser.add_argument("--sensitivity", type=float, default=1.0, help="Sensitivity factor.")
 
 # recorder_parameter
@@ -97,7 +97,7 @@ def main():
 
     env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
     env_cfg.use_teleop_device(args_cli.teleop_device)
-    env_cfg.seed = args_cli.seed
+    env_cfg.seed = args_cli.seed if args_cli.seed is not None else int(time.time())
     task_name = args_cli.task
 
     # precheck task and teleop device

--- a/scripts/mimic/annotate_demos.py
+++ b/scripts/mimic/annotate_demos.py
@@ -1,0 +1,445 @@
+# Copyright (c) 2024-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Script to add mimic annotations to demos to be used as source demos for mimic dataset generation.
+"""
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+# Launching Isaac Sim Simulator first.
+
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Annotate demonstrations for Isaac Lab environments.")
+parser.add_argument("--task", type=str, default=None, help="Name of the task.")
+parser.add_argument(
+    "--input_file", type=str, default="./datasets/dataset.hdf5", help="File name of the dataset to be annotated."
+)
+parser.add_argument(
+    "--output_file",
+    type=str,
+    default="./datasets/dataset_annotated.hdf5",
+    help="File name of the annotated output dataset file.",
+)
+parser.add_argument("--auto", action="store_true", default=False, help="Automatically annotate subtasks.")
+parser.add_argument(
+    "--enable_pinocchio",
+    action="store_true",
+    default=False,
+    help="Enable Pinocchio.",
+)
+
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+if args_cli.enable_pinocchio:
+    # Import pinocchio before AppLauncher to force the use of the version installed by IsaacLab and not the one installed by Isaac Sim
+    # pinocchio is required by the Pink IK controllers and the GR1T2 retargeter
+    import pinocchio  # noqa: F401
+
+# launch the simulator
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import contextlib
+import gymnasium as gym
+import os
+import torch
+
+import isaaclab_mimic.envs  # noqa: F401
+
+if args_cli.enable_pinocchio:
+    import isaaclab_mimic.envs.pinocchio_envs  # noqa: F401
+
+# Only enables inputs if this script is NOT headless mode
+if not args_cli.headless and not os.environ.get("HEADLESS", 0):
+    from isaaclab.devices import Se3Keyboard
+
+from isaaclab.envs import ManagerBasedRLMimicEnv
+from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
+from isaaclab.managers import RecorderTerm, RecorderTermCfg, TerminationTermCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.datasets import EpisodeData, HDF5DatasetFileHandler
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
+is_paused = False
+current_action_index = 0
+marked_subtask_action_indices = []
+skip_episode = False
+
+
+def play_cb():
+    global is_paused
+    is_paused = False
+
+
+def pause_cb():
+    global is_paused
+    is_paused = True
+
+
+def skip_episode_cb():
+    global skip_episode
+    skip_episode = True
+
+
+def mark_subtask_cb():
+    global current_action_index, marked_subtask_action_indices
+    marked_subtask_action_indices.append(current_action_index)
+    print(f"Marked a subtask signal at action index: {current_action_index}")
+
+
+class PreStepDatagenInfoRecorder(RecorderTerm):
+    """Recorder term that records the datagen info data in each step."""
+
+    def record_pre_step(self):
+        eef_pose_dict = {}
+        for eef_name in self._env.cfg.subtask_configs.keys():
+            eef_pose_dict[eef_name] = self._env.get_robot_eef_pose(eef_name=eef_name)
+
+        datagen_info = {
+            "object_pose": self._env.get_object_poses(),
+            "eef_pose": eef_pose_dict,
+            "target_eef_pose": self._env.action_to_target_eef_pose(self._env.action_manager.action),
+        }
+        return "obs/datagen_info", datagen_info
+
+
+@configclass
+class PreStepDatagenInfoRecorderCfg(RecorderTermCfg):
+    """Configuration for the datagen info recorder term."""
+
+    class_type: type[RecorderTerm] = PreStepDatagenInfoRecorder
+
+
+class PreStepSubtaskTermsObservationsRecorder(RecorderTerm):
+    """Recorder term that records the subtask completion observations in each step."""
+
+    def record_pre_step(self):
+        return "obs/datagen_info/subtask_term_signals", self._env.get_subtask_term_signals()
+
+
+@configclass
+class PreStepSubtaskTermsObservationsRecorderCfg(RecorderTermCfg):
+    """Configuration for the step subtask terms observation recorder term."""
+
+    class_type: type[RecorderTerm] = PreStepSubtaskTermsObservationsRecorder
+
+
+@configclass
+class MimicRecorderManagerCfg(ActionStateRecorderManagerCfg):
+    """Mimic specific recorder terms."""
+
+    record_pre_step_datagen_info = PreStepDatagenInfoRecorderCfg()
+    record_pre_step_subtask_term_signals = PreStepSubtaskTermsObservationsRecorderCfg()
+
+
+def main():
+    """Add Isaac Lab Mimic annotations to the given demo dataset file."""
+    global is_paused, current_action_index, marked_subtask_action_indices
+
+    # Load input dataset to be annotated
+    if not os.path.exists(args_cli.input_file):
+        raise FileNotFoundError(f"The input dataset file {args_cli.input_file} does not exist.")
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.open(args_cli.input_file)
+    env_name = dataset_file_handler.get_env_name()
+    episode_count = dataset_file_handler.get_num_episodes()
+
+    if episode_count == 0:
+        print("No episodes found in the dataset.")
+        exit()
+
+    # get output directory path and file name (without extension) from cli arguments
+    output_dir = os.path.dirname(args_cli.output_file)
+    output_file_name = os.path.splitext(os.path.basename(args_cli.output_file))[0]
+    # create output directory if it does not exist
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    if args_cli.task is not None:
+        env_name = args_cli.task.split(":")[-1]
+    if env_name is None:
+        raise ValueError("Task/env name was not specified nor found in the dataset.")
+
+    env_cfg = parse_env_cfg(env_name, device=args_cli.device, num_envs=1)
+
+    env_cfg.env_name = env_name
+
+    # extract success checking function to invoke manually
+    success_term = None
+    if hasattr(env_cfg.terminations, "success"):
+        success_term = env_cfg.terminations.success
+        env_cfg.terminations.success = None
+    else:
+        raise NotImplementedError("No success termination term was found in the environment.")
+
+    # Disable all termination terms
+    env_cfg.terminations = None
+
+    # Set up recorder terms for mimic annotations
+    env_cfg.recorders: MimicRecorderManagerCfg = MimicRecorderManagerCfg()
+    if not args_cli.auto:
+        # disable subtask term signals recorder term if in manual mode
+        env_cfg.recorders.record_pre_step_subtask_term_signals = None
+
+    env_cfg.recorders.dataset_export_dir_path = output_dir
+    env_cfg.recorders.dataset_filename = output_file_name
+
+    # create environment from loaded config
+    env: ManagerBasedRLMimicEnv = gym.make(args_cli.task, cfg=env_cfg).unwrapped
+
+    if not isinstance(env, ManagerBasedRLMimicEnv):
+        raise ValueError("The environment should be derived from ManagerBasedRLMimicEnv")
+
+    if args_cli.auto:
+        # check if the mimic API env.get_subtask_term_signals() is implemented
+        if env.get_subtask_term_signals.__func__ is ManagerBasedRLMimicEnv.get_subtask_term_signals:
+            raise NotImplementedError(
+                "The environment does not implement the get_subtask_term_signals method required "
+                "to run automatic annotations."
+            )
+    else:
+        # get subtask termination signal names for each eef from the environment configs
+        subtask_term_signal_names = {}
+        for eef_name, eef_subtask_configs in env.cfg.subtask_configs.items():
+            subtask_term_signal_names[eef_name] = [
+                subtask_config.subtask_term_signal for subtask_config in eef_subtask_configs
+            ]
+            # no need to annotate the last subtask term signal, so remove it from the list
+            subtask_term_signal_names[eef_name].pop()
+
+    # reset environment
+    env.reset()
+
+    # Only enables inputs if this script is NOT headless mode
+    if not args_cli.headless and not os.environ.get("HEADLESS", 0):
+        keyboard_interface = Se3Keyboard(pos_sensitivity=0.1, rot_sensitivity=0.1)
+        keyboard_interface.add_callback("N", play_cb)
+        keyboard_interface.add_callback("B", pause_cb)
+        keyboard_interface.add_callback("Q", skip_episode_cb)
+        if not args_cli.auto:
+            keyboard_interface.add_callback("S", mark_subtask_cb)
+        keyboard_interface.reset()
+
+    # simulate environment -- run everything in inference mode
+    exported_episode_count = 0
+    processed_episode_count = 0
+    with contextlib.suppress(KeyboardInterrupt) and torch.inference_mode():
+        while simulation_app.is_running() and not simulation_app.is_exiting():
+            # Iterate over the episodes in the loaded dataset file
+            for episode_index, episode_name in enumerate(dataset_file_handler.get_episode_names()):
+                processed_episode_count += 1
+                print(f"\nAnnotating episode #{episode_index} ({episode_name})")
+                episode = dataset_file_handler.load_episode(episode_name, env.device)
+
+                is_episode_annotated_successfully = False
+                if args_cli.auto:
+                    is_episode_annotated_successfully = annotate_episode_in_auto_mode(env, episode, success_term)
+                else:
+                    is_episode_annotated_successfully = annotate_episode_in_manual_mode(
+                        env, episode, success_term, subtask_term_signal_names
+                    )
+
+                if is_episode_annotated_successfully and not skip_episode:
+                    # set success to the recorded episode data and export to file
+                    env.recorder_manager.set_success_to_episodes(
+                        None, torch.tensor([[True]], dtype=torch.bool, device=env.device)
+                    )
+                    env.recorder_manager.export_episodes()
+                    exported_episode_count += 1
+                    print("\tExported the annotated episode.")
+                else:
+                    print("\tSkipped exporting the episode due to incomplete subtask annotations.")
+            break
+
+    print(
+        f"\nExported {exported_episode_count} (out of {processed_episode_count}) annotated"
+        f" episode{'s' if exported_episode_count > 1 else ''}."
+    )
+    print("Exiting the app.")
+
+    # Close environment after annotation is complete
+    env.close()
+
+
+def replay_episode(
+    env: ManagerBasedRLMimicEnv,
+    episode: EpisodeData,
+    success_term: TerminationTermCfg | None = None,
+) -> bool:
+    """Replays an episode in the environment.
+
+    This function replays the given recorded episode in the environment. It can optionally check if the task
+    was successfully completed using a success termination condition input.
+
+    Args:
+        env: The environment to replay the episode in.
+        episode: The recorded episode data to replay.
+        success_term: Optional termination term to check for task success.
+
+    Returns:
+        True if the episode was successfully replayed and the success condition was met (if provided),
+        False otherwise.
+    """
+    global current_action_index, skip_episode, is_paused
+    # read initial state and actions from the loaded episode
+    initial_state = episode.data["initial_state"]
+    actions = episode.data["actions"]
+    env.sim.reset()
+    env.recorder_manager.reset()
+    env.reset_to(initial_state, None, is_relative=True)
+    first_action = True
+    for action_index, action in enumerate(actions):
+        current_action_index = action_index
+        if first_action:
+            first_action = False
+        else:
+            while is_paused or skip_episode:
+                env.sim.render()
+                if skip_episode:
+                    return False
+                continue
+        action_tensor = torch.Tensor(action).reshape([1, action.shape[0]])
+        env.step(torch.Tensor(action_tensor))
+    if success_term is not None:
+        if not bool(success_term.func(env, **success_term.params)[0]):
+            return False
+    return True
+
+
+def annotate_episode_in_auto_mode(
+    env: ManagerBasedRLMimicEnv,
+    episode: EpisodeData,
+    success_term: TerminationTermCfg | None = None,
+) -> bool:
+    """Annotates an episode in automatic mode.
+
+    This function replays the given episode in the environment and checks if the task was successfully completed.
+    If the task was not completed, it will print a message and return False. Otherwise, it will check if all the
+    subtask term signals are annotated and return True if they are, False otherwise.
+
+    Args:
+        env: The environment to replay the episode in.
+        episode: The recorded episode data to replay.
+        success_term: Optional termination term to check for task success.
+
+    Returns:
+        True if the episode was successfully annotated, False otherwise.
+    """
+    global skip_episode
+    skip_episode = False
+    is_episode_annotated_successfully = replay_episode(env, episode, success_term)
+    if skip_episode:
+        print("\tSkipping the episode.")
+        return False
+    if not is_episode_annotated_successfully:
+        print("\tThe final task was not completed.")
+    else:
+        # check if all the subtask term signals are annotated
+        annotated_episode = env.recorder_manager.get_episode(0)
+        subtask_term_signal_dict = annotated_episode.data["obs"]["datagen_info"]["subtask_term_signals"]
+        for signal_name, signal_flags in subtask_term_signal_dict.items():
+            if not torch.any(signal_flags):
+                is_episode_annotated_successfully = False
+                print(f'\tDid not detect completion for the subtask "{signal_name}".')
+    return is_episode_annotated_successfully
+
+
+def annotate_episode_in_manual_mode(
+    env: ManagerBasedRLMimicEnv,
+    episode: EpisodeData,
+    success_term: TerminationTermCfg | None = None,
+    subtask_term_signal_names: dict[str, list[str]] = {},
+) -> bool:
+    """Annotates an episode in manual mode.
+
+    This function replays the given episode in the environment and allows for manual marking of subtask term signals.
+    It iterates over each eef and prompts the user to mark the subtask term signals for that eef.
+
+    Args:
+        env: The environment to replay the episode in.
+        episode: The recorded episode data to replay.
+        success_term: Optional termination term to check for task success.
+        subtask_term_signal_names: Dictionary mapping eef names to lists of subtask term signal names.
+
+    Returns:
+        True if the episode was successfully annotated, False otherwise.
+    """
+    global is_paused, marked_subtask_action_indices, skip_episode
+    # iterate over the eefs for marking subtask term signals
+    subtask_term_signal_action_indices = {}
+    for eef_name, eef_subtask_term_signal_names in subtask_term_signal_names.items():
+        # skip if no subtask annotation is needed for this eef
+        if len(eef_subtask_term_signal_names) == 0:
+            continue
+
+        while True:
+            is_paused = True
+            skip_episode = False
+            print(f'\tPlaying the episode for subtask annotations for eef "{eef_name}".')
+            print("\tSubtask signals to annotate:")
+            print(f"\t\t- Termination:\t{eef_subtask_term_signal_names}")
+
+            print('\n\tPress "N" to begin.')
+            print('\tPress "B" to pause.')
+            print('\tPress "S" to annotate subtask signals.')
+            print('\tPress "Q" to skip the episode.\n')
+            marked_subtask_action_indices = []
+            task_success_result = replay_episode(env, episode, success_term)
+            if skip_episode:
+                print("\tSkipping the episode.")
+                return False
+
+            print(f"\tSubtasks marked at action indices: {marked_subtask_action_indices}")
+            expected_subtask_signal_count = len(eef_subtask_term_signal_names)
+            if task_success_result and expected_subtask_signal_count == len(marked_subtask_action_indices):
+                print(f'\tAll {expected_subtask_signal_count} subtask signals for eef "{eef_name}" were annotated.')
+                for marked_signal_index in range(expected_subtask_signal_count):
+                    # collect subtask term signal action indices
+                    subtask_term_signal_action_indices[eef_subtask_term_signal_names[marked_signal_index]] = (
+                        marked_subtask_action_indices[marked_signal_index]
+                    )
+                break
+
+            if not task_success_result:
+                print("\tThe final task was not completed.")
+                return False
+
+            if expected_subtask_signal_count != len(marked_subtask_action_indices):
+                print(
+                    f"\tOnly {len(marked_subtask_action_indices)} out of"
+                    f' {expected_subtask_signal_count} subtask signals for eef "{eef_name}" were'
+                    " annotated."
+                )
+
+            print(f'\tThe episode will be replayed again for re-marking subtask signals for the eef "{eef_name}".\n')
+
+    annotated_episode = env.recorder_manager.get_episode(0)
+    for (
+        subtask_term_signal_name,
+        subtask_term_signal_action_index,
+    ) in subtask_term_signal_action_indices.items():
+        # subtask termination signal is false until subtask is complete, and true afterwards
+        subtask_signals = torch.ones(len(episode.data["actions"]), dtype=torch.bool)
+        subtask_signals[:subtask_term_signal_action_index] = False
+        annotated_episode.add(f"obs/datagen_info/subtask_term_signals/{subtask_term_signal_name}", subtask_signals)
+    return True
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/scripts/mimic/eef_action_process.py
+++ b/scripts/mimic/eef_action_process.py
@@ -1,0 +1,90 @@
+"""Script to run a leisaac replay with leisaac in the simulation."""
+
+"""Launch Isaac Sim Simulator first."""
+import multiprocessing
+if multiprocessing.get_start_method() != "spawn":
+    multiprocessing.set_start_method("spawn", force=True)
+import argparse
+
+from isaaclab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="leisaac replay for leisaac in the simulation.")
+parser.add_argument("--input_file", type=str, default="./datasets/mimic-lift-cube-example.hdf5", help="File path to load mimic recorded demos.")
+parser.add_argument("--output_file", type=str, default="./datasets/processed_mimic-lift-cube-example.hdf5", help="File path to save processed mimic recorded demos.")
+parser.add_argument("--to_ik", action="store_true", help="Whether to convert the action to ik action.")
+parser.add_argument("--to_joint", action="store_true", help="Whether to convert the action to joint action.")
+
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+app_launcher_args = vars(args_cli)
+
+# launch omniverse app
+app_launcher = AppLauncher(app_launcher_args)
+simulation_app = app_launcher.app
+
+import os
+import torch
+from copy import deepcopy
+from tqdm import tqdm
+
+from isaaclab.utils.datasets import HDF5DatasetFileHandler, EpisodeData
+
+
+def joint_action_to_ik(episode_data: EpisodeData) -> EpisodeData:
+    """Convert the action to ik action."""
+    eef_state = episode_data.data['obs']['ee_frame_state']
+
+    action = episode_data.data['actions']
+    gripper_action = action[:, -1:]
+    new_actions = torch.cat([eef_state, gripper_action], dim=1)
+    episode_data.data['actions'] = new_actions
+
+    return episode_data
+
+
+def ik_action_to_joint(episode_data: EpisodeData) -> EpisodeData:
+    """Convert the action to joint action."""
+    return episode_data
+
+
+def main():
+    """Process the eef action of the mimic annotated recorded demos."""
+    # check arguments
+    if args_cli.to_ik and args_cli.to_joint:
+        raise ValueError("Cannot convert to both ik and joint action at the same time.")
+    if not args_cli.to_ik and not args_cli.to_joint:
+        raise ValueError("Must convert to either ik or joint action.")
+
+    # Load dataset
+    if not os.path.exists(args_cli.input_file):
+        raise FileNotFoundError(f"The dataset file {args_cli.input_file} does not exist.")
+    input_dataset_handler = HDF5DatasetFileHandler()
+    input_dataset_handler.open(args_cli.input_file)
+
+    output_dataset_handler = HDF5DatasetFileHandler()
+    output_dataset_handler.create(args_cli.output_file)
+
+    episode_names = list(input_dataset_handler.get_episode_names())
+    for episode_name in tqdm(episode_names):
+        episode_data = input_dataset_handler.load_episode(episode_name, device=args_cli.device)
+        if episode_data.success is not None and not episode_data.success:
+            continue
+        process_episode_data = deepcopy(episode_data)
+        if args_cli.to_ik:
+            process_episode_data = joint_action_to_ik(process_episode_data)
+        elif args_cli.to_joint:
+            process_episode_data = ik_action_to_joint(process_episode_data)
+        output_dataset_handler.write_episode(process_episode_data)
+
+    input_dataset_handler.close()
+    output_dataset_handler.flush()
+    output_dataset_handler.close()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()

--- a/scripts/mimic/eef_action_process.py
+++ b/scripts/mimic/eef_action_process.py
@@ -48,6 +48,11 @@ def joint_action_to_ik(episode_data: EpisodeData) -> EpisodeData:
 
 def ik_action_to_joint(episode_data: EpisodeData) -> EpisodeData:
     """Convert the action to joint action."""
+    joint_pos = episode_data.data['obs']['joint_pos']
+
+    new_actions = joint_pos
+    episode_data.data['actions'] = new_actions
+
     return episode_data
 
 

--- a/scripts/mimic/generate_dataset.py
+++ b/scripts/mimic/generate_dataset.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2024-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Main data generation script.
+"""
+
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Generate demonstrations for Isaac Lab environments.")
+parser.add_argument("--task", type=str, default=None, help="Name of the task.")
+parser.add_argument("--generation_num_trials", type=int, help="Number of demos to be generated.", default=None)
+parser.add_argument(
+    "--num_envs", type=int, default=1, help="Number of environments to instantiate for generating datasets."
+)
+parser.add_argument("--input_file", type=str, default=None, required=True, help="File path to the source dataset file.")
+parser.add_argument(
+    "--output_file",
+    type=str,
+    default="./datasets/output_dataset.hdf5",
+    help="File path to export recorded and generated episodes.",
+)
+parser.add_argument(
+    "--pause_subtask",
+    action="store_true",
+    help="pause after every subtask during generation for debugging - only useful with render flag",
+)
+parser.add_argument(
+    "--enable_pinocchio",
+    action="store_true",
+    default=False,
+    help="Enable Pinocchio.",
+)
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+if args_cli.enable_pinocchio:
+    # Import pinocchio before AppLauncher to force the use of the version installed by IsaacLab and not the one installed by Isaac Sim
+    # pinocchio is required by the Pink IK controllers and the GR1T2 retargeter
+    import pinocchio  # noqa: F401
+
+# launch the simulator
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import asyncio
+import gymnasium as gym
+import inspect
+import numpy as np
+import random
+import torch
+
+import omni
+
+from isaaclab.envs import ManagerBasedRLMimicEnv
+
+import isaaclab_mimic.envs  # noqa: F401
+
+if args_cli.enable_pinocchio:
+    import isaaclab_mimic.envs.pinocchio_envs  # noqa: F401
+from isaaclab_mimic.datagen.generation import env_loop, setup_async_generation, setup_env_config
+from isaaclab_mimic.datagen.utils import get_env_name_from_dataset, setup_output_paths
+
+import isaaclab_tasks  # noqa: F401
+
+
+def main():
+    num_envs = args_cli.num_envs
+
+    # Setup output paths and get env name
+    output_dir, output_file_name = setup_output_paths(args_cli.output_file)
+    task_name = args_cli.task
+    if task_name:
+        task_name = args_cli.task.split(":")[-1]
+    env_name = task_name or get_env_name_from_dataset(args_cli.input_file)
+
+    # Configure environment
+    env_cfg, success_term = setup_env_config(
+        env_name=env_name,
+        output_dir=output_dir,
+        output_file_name=output_file_name,
+        num_envs=num_envs,
+        device=args_cli.device,
+        generation_num_trials=args_cli.generation_num_trials,
+    )
+
+    # create environment
+    env = gym.make(env_name, cfg=env_cfg).unwrapped
+
+    if not isinstance(env, ManagerBasedRLMimicEnv):
+        raise ValueError("The environment should be derived from ManagerBasedRLMimicEnv")
+
+    # check if the mimic API from this environment contains decprecated signatures
+    if "action_noise_dict" not in inspect.signature(env.target_eef_pose_to_action).parameters:
+        omni.log.warn(
+            f'The "noise" parameter in the "{env_name}" environment\'s mimic API "target_eef_pose_to_action", '
+            "is deprecated. Please update the API to take action_noise_dict instead."
+        )
+
+    # set seed for generation
+    random.seed(env.cfg.datagen_config.seed)
+    np.random.seed(env.cfg.datagen_config.seed)
+    torch.manual_seed(env.cfg.datagen_config.seed)
+
+    # reset before starting
+    env.reset()
+
+    # Setup and run async data generation
+    async_components = setup_async_generation(
+        env=env,
+        num_envs=args_cli.num_envs,
+        input_file=args_cli.input_file,
+        success_term=success_term,
+        pause_subtask=args_cli.pause_subtask,
+    )
+
+    try:
+        asyncio.ensure_future(asyncio.gather(*async_components["tasks"]))
+        env_loop(
+            env,
+            async_components["reset_queue"],
+            async_components["action_queue"],
+            async_components["info_pool"],
+            async_components["event_loop"],
+        )
+    except asyncio.CancelledError:
+        print("Tasks were cancelled.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nProgram interrupted by user. Exiting...")
+    # close sim app
+    simulation_app.close()

--- a/scripts/mimic/generate_dataset.py
+++ b/scripts/mimic/generate_dataset.py
@@ -75,6 +75,8 @@ from isaaclab_mimic.datagen.utils import get_env_name_from_dataset, setup_output
 
 import isaaclab_tasks  # noqa: F401
 
+import leisaac  # noqa: F401
+
 
 def main():
     num_envs = args_cli.num_envs

--- a/scripts/tools/dataset_filter.py
+++ b/scripts/tools/dataset_filter.py
@@ -1,0 +1,1 @@
+# TODO: filter the dataset to only include the data that is valid and successful.

--- a/scripts/tools/dataset_filter.py
+++ b/scripts/tools/dataset_filter.py
@@ -1,1 +1,0 @@
-# TODO: filter the dataset to only include the data that is valid and successful.

--- a/source/leisaac/leisaac/assets/robots/lerobot.py
+++ b/source/leisaac/leisaac/assets/robots/lerobot.py
@@ -79,7 +79,7 @@ SO101_FOLLOWER_REST_POSE_RANGE = {
     "shoulder_pan": (0 - 20.0, 0 + 20.0),  # 0 degree
     "shoulder_lift": (-100.0 - 20.0, -100.0 + 20.0),  # -100 degree
     "elbow_flex": (90.0 - 20.0, 90.0 + 20.0),  # 90 degree
-    "wrist_flex": (50.0 - 20.0, 50.0 + 20.0),  # 50 degree
+    "wrist_flex": (50.0 - 30.0, 50.0 + 30.0),  # 50 degree
     "wrist_roll": (0.0 - 20.0, 0.0 + 20.0),  # 0 degree
     "gripper": (-10.0 - 20.0, -10.0 + 20.0),  # -10 degree
 }

--- a/source/leisaac/leisaac/devices/action_process.py
+++ b/source/leisaac/leisaac/devices/action_process.py
@@ -50,6 +50,18 @@ def init_action_cfg(action_cfg, device):
             joint_names=["gripper"],
             scale=1.0,
         )
+    elif device in ['mimic_ik_abs_so101_leader']:
+        action_cfg.arm_action = mdp.DifferentialInverseKinematicsActionCfg(
+            asset_name="robot",
+            joint_names=["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll"],
+            body_name="gripper",
+            controller=mdp.DifferentialIKControllerCfg(command_type="pose", ik_method="dls", use_relative_mode=False),
+        )
+        action_cfg.gripper_action = mdp.JointPositionActionCfg(
+            asset_name="robot",
+            joint_names=["gripper"],
+            scale=1.0,
+        )
     else:
         action_cfg.arm_action = None
         action_cfg.gripper_action = None

--- a/source/leisaac/leisaac/enhance/envs/manager_based_rl_digital_twin_env.py
+++ b/source/leisaac/leisaac/enhance/envs/manager_based_rl_digital_twin_env.py
@@ -38,7 +38,7 @@ class ManagerBasedRLDigitalTwinEnv(ManagerBasedRLEnv):
         Returns:
             the resized overlay image.(C, H, W)
         """
-        image = torch.from_numpy(cv2.imread(path))
+        image = torch.from_numpy(cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB))
 
         if image.dim() == 3 and image.shape[2] in [3, 4]:  # [H, W, C]
             image = image.permute(2, 0, 1)  # [C, H, W]

--- a/source/leisaac/leisaac/enhance/envs/manager_based_rl_leisaac_mimic_env.py
+++ b/source/leisaac/leisaac/enhance/envs/manager_based_rl_leisaac_mimic_env.py
@@ -1,0 +1,81 @@
+import torch
+from collections.abc import Sequence
+
+import isaaclab.utils.math as PoseUtils
+from isaaclab.envs import ManagerBasedRLMimicEnv, ManagerBasedRLEnvCfg
+
+
+class ManagerBasedRLLeIsaacMimicEnv(ManagerBasedRLMimicEnv):
+    """
+    Environment for the LeIsaac task with mimic environment.
+    """
+
+    def __init__(self, cfg: ManagerBasedRLEnvCfg, render_mode: str | None = None, **kwargs):
+        cfg.use_teleop_device('mimic_ik_abs_so101_leader')
+        super().__init__(cfg, render_mode, **kwargs)
+        self.robot_root_pos = self.scene['robot'].data.root_pos_w
+        self.robot_root_quat = self.scene['robot'].data.root_quat_w
+
+    def get_robot_eef_pose(self, eef_name: str, env_ids: Sequence[int] | None = None) -> torch.Tensor:
+        if env_ids is None:
+            env_ids = slice(None)
+
+        # robot coordinate
+        eef_state = self.obs_buf["policy"]["ee_frame_state"][env_ids]
+        eef_pos = eef_state[:, :3]
+        eef_quat = eef_state[:, 3:7]
+        # quat: (w, x, y, z)
+        eef_pose = PoseUtils.make_pose(eef_pos, PoseUtils.matrix_from_quat(eef_quat))
+        return eef_pose
+
+    def target_eef_pose_to_action(
+        self,
+        target_eef_pose_dict: dict,
+        gripper_action_dict: dict,
+        action_noise_dict: dict | None = None,
+        env_id: int = 0,
+    ) -> torch.Tensor:
+        (target_eef_pose,) = target_eef_pose_dict.values()
+        target_eef_pos, target_eef_rot = PoseUtils.unmake_pose(target_eef_pose)
+        target_eef_quat = PoseUtils.quat_from_matrix(target_eef_rot)
+
+        (gripper_action,) = gripper_action_dict.values()
+
+        # add noise to action
+        pose_action = torch.cat([target_eef_pos, target_eef_quat], dim=0)
+        eef_name = list(self.cfg.subtask_configs.keys())[0]
+        if action_noise_dict is not None:
+            noise = action_noise_dict[eef_name] * torch.randn_like(pose_action)
+            pose_action += noise
+
+        return torch.cat([pose_action, gripper_action], dim=0).unsqueeze(0)
+
+    def action_to_target_eef_pose(self, action: torch.Tensor) -> dict[str, torch.Tensor]:
+        eef_name = list(self.cfg.subtask_configs.keys())[0]
+
+        target_eef_pos = action[:, :3]
+        target_eef_quat = action[:, 3:7]
+        target_eef_rot = PoseUtils.matrix_from_quat(target_eef_quat)
+
+        target_eef_pose = PoseUtils.make_pose(target_eef_pos, target_eef_rot).clone()
+
+        return {eef_name: target_eef_pose}
+
+    def actions_to_gripper_actions(self, actions: torch.Tensor) -> dict[str, torch.Tensor]:
+        eef_name = list(self.cfg.subtask_configs.keys())[0]
+        return {eef_name: actions[:, -1:]}
+
+    def get_object_poses(self, env_ids: Sequence[int] | None = None):
+        if env_ids is None:
+            env_ids = slice(None)
+
+        rigid_object_state = self.scene.get_state(is_relative=False)["rigid_object"]
+        object_pose_matrix = dict()
+        for obj_name, obj_state in rigid_object_state.items():
+            obj_pos_w, obj_quat_w = obj_state["root_pose"][env_ids, :3], obj_state["root_pose"][env_ids, 3:7]
+            obj_pos_robot, obj_quat_robot = PoseUtils.subtract_frame_transforms(
+                self.robot_root_pos[env_ids], self.robot_root_quat[env_ids], obj_pos_w, obj_quat_w
+            )
+            object_pose_matrix[obj_name] = PoseUtils.make_pose(obj_pos_robot, PoseUtils.matrix_from_quat(obj_quat_robot))
+
+        return object_pose_matrix

--- a/source/leisaac/leisaac/enhance/envs/mdp/events.py
+++ b/source/leisaac/leisaac/enhance/envs/mdp/events.py
@@ -26,13 +26,13 @@ def randomize_camera_uniform(
     """
     asset: Camera = env.scene[asset_cfg.name]
 
-    ori_pos_w = asset.data.pos_w
+    ori_pos_w = asset.data.pos_w[env_ids]
     if convention == "ros":
-        ori_quat_w = asset.data.quat_w_ros
+        ori_quat_w = asset.data.quat_w_ros[env_ids]
     elif convention == "opengl":
-        ori_quat_w = asset.data.quat_w_opengl
+        ori_quat_w = asset.data.quat_w_opengl[env_ids]
     elif convention == "world":
-        ori_quat_w = asset.data.quat_w_world
+        ori_quat_w = asset.data.quat_w_world[env_ids]
 
     range_list = [pose_range.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]]
     ranges = torch.tensor(range_list, device=asset.device)

--- a/source/leisaac/leisaac/tasks/lift_cube/__init__.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/__init__.py
@@ -17,3 +17,12 @@ gym.register(
         "env_cfg_entry_point": f"{__name__}.lift_cube_env_cfg:LiftCubeDigitalTwinEnvCfg",
     },
 )
+
+gym.register(
+    id="LeIsaac-SO101-LiftCube-Mimic-v0",
+    entry_point=f"{__name__}.lift_cube_mimic_env:LiftCubeMimicEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.lift_cube_mimic_env_cfg:LiftCubeMimicEnvCfg",
+    },
+)

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
@@ -12,7 +12,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
-from isaaclab.sensors import TiledCameraCfg
+from isaaclab.sensors import TiledCameraCfg, FrameTransformerCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
 
@@ -33,6 +33,12 @@ class LiftCubeSceneCfg(InteractiveSceneCfg):
     scene: AssetBaseCfg = TABLE_WITH_CUBE_CFG.replace(prim_path="{ENV_REGEX_NS}/Scene")
 
     robot: ArticulationCfg = SO101_FOLLOWER_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    ee_frame: FrameTransformerCfg = FrameTransformerCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/base",
+        debug_vis=False,
+        target_frames=[FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/gripper", name="gripper")]
+    )
 
     front: TiledCameraCfg = TiledCameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/base/front_camera",
@@ -85,6 +91,7 @@ class ObservationsCfg:
         joint_vel_rel = ObsTerm(func=mdp.joint_vel_rel)
         actions = ObsTerm(func=mdp.last_action)
         front = ObsTerm(func=mdp.image, params={"sensor_cfg": SceneEntityCfg("front"), "data_type": "rgb", "normalize": False})
+        ee_frame_state = ObsTerm(func=mdp.ee_frame_state, params={"ee_frame_cfg": SceneEntityCfg("ee_frame"), "robot_cfg": SceneEntityCfg("robot")})
 
         def __post_init__(self):
             self.enable_corruption = True
@@ -141,10 +148,14 @@ class LiftCubeEnvCfg(ManagerBasedRLEnvCfg):
 
         self.scene.robot.init_state.pos = (0.35, -0.64, 0.01)
 
+        self.scene.ee_frame.visualizer_cfg.markers['frame'].scale = (0.05, 0.05, 0.05)
+
         parse_usd_and_create_subassets(TABLE_WITH_CUBE_USD_PATH, self)
 
         domain_randomization(self, random_options=[
-            randomize_object_uniform("cube", pose_range={"x": (-0.1, 0.1), "y": (-0.1, 0.1), "z": (0.0, 0.0)}),
+            randomize_object_uniform("cube", pose_range={
+                "x": (-0.1, 0.1), "y": (-0.1, 0.1), "z": (0.0, 0.0),
+                "yaw": (-90 * torch.pi / 180, 90 * torch.pi / 180)}),
             randomize_camera_uniform("front", pose_range={
                 "x": (-0.005, 0.005), "y": (-0.005, 0.005), "z": (-0.005, 0.005),
                 "roll": (-0.05 * torch.pi / 180, 0.05 * torch.pi / 180),

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
@@ -36,10 +36,10 @@ class LiftCubeSceneCfg(InteractiveSceneCfg):
 
     front: TiledCameraCfg = TiledCameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/base/front_camera",
-        offset=TiledCameraCfg.OffsetCfg(pos=(0.65, -0.3, 0.45), rot=(0.6432, 0.40646, 0.32495, 0.56169), convention="opengl"),  # wxyz
+        offset=TiledCameraCfg.OffsetCfg(pos=(-0.6, -0.75, 0.38), rot=(0.77337, 0.55078, -0.2374, -0.20537), convention="opengl"),  # wxyz
         data_types=["rgb"],
         spawn=sim_utils.PinholeCameraCfg(
-            focal_length=37.8,
+            focal_length=40.6,
             focus_distance=400.0,
             horizontal_aperture=38.11,
             clipping_range=(0.01, 50.0),
@@ -52,7 +52,7 @@ class LiftCubeSceneCfg(InteractiveSceneCfg):
 
     light = AssetBaseCfg(
         prim_path="{ENV_REGEX_NS}/Light",
-        spawn=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+        spawn=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=1000.0),
     )
 
 
@@ -168,7 +168,7 @@ class LiftCubeDigitalTwinEnvCfg(LiftCubeEnvCfg, ManagerBasedRLDigitalTwinEnvCfg)
     rgb_overlay_mode: str = "background"
 
     rgb_overlay_paths: Dict[str, str] = {
-        "front": "greenscreen/background-lift-cube.jpg"
+        "front": "greenscreen/background-lift-cube.png"
     }
 
     render_objects: List[SceneEntityCfg] = [

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py
@@ -154,8 +154,8 @@ class LiftCubeEnvCfg(ManagerBasedRLEnvCfg):
 
         domain_randomization(self, random_options=[
             randomize_object_uniform("cube", pose_range={
-                "x": (-0.1, 0.1), "y": (-0.1, 0.1), "z": (0.0, 0.0),
-                "yaw": (-90 * torch.pi / 180, 90 * torch.pi / 180)}),
+                "x": (-0.075, 0.075), "y": (-0.075, 0.075), "z": (0.0, 0.0),
+                "yaw": (-30 * torch.pi / 180, 30 * torch.pi / 180)}),
             randomize_camera_uniform("front", pose_range={
                 "x": (-0.005, 0.005), "y": (-0.005, 0.005), "z": (-0.005, 0.005),
                 "roll": (-0.05 * torch.pi / 180, 0.05 * torch.pi / 180),

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env.py
@@ -1,0 +1,13 @@
+import torch
+from collections.abc import Sequence
+
+from leisaac.enhance.envs.manager_based_rl_leisaac_mimic_env import ManagerBasedRLLeIsaacMimicEnv
+
+
+class LiftCubeMimicEnv(ManagerBasedRLLeIsaacMimicEnv):
+    """
+    Environment for the lift cube task with mimic environment.
+    """
+
+    def get_subtask_term_signals(self, env_ids: Sequence[int] | None = None) -> dict[str, torch.Tensor]:
+        pass

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env_cfg.py
@@ -43,7 +43,7 @@ class LiftCubeMimicEnvCfg(LiftCubeEnvCfg, MimicEnvCfg):
                 # Optional parameters for the selection strategy function
                 selection_strategy_kwargs={"nn_k": 3},
                 # Amount of action noise to apply during this subtask
-                action_noise=0.03,
+                action_noise=0.003,
                 # Number of interpolation steps to bridge to this subtask segment
                 num_interpolation_steps=5,
                 # Additional fixed steps for the robot to reach the necessary pose
@@ -61,7 +61,7 @@ class LiftCubeMimicEnvCfg(LiftCubeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(0, 0),
                 selection_strategy="random",
                 selection_strategy_kwargs={},
-                action_noise=0.03,
+                action_noise=0.0001,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,

--- a/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/lift_cube_mimic_env_cfg.py
@@ -1,0 +1,70 @@
+from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
+from isaaclab.utils import configclass
+
+from .lift_cube_env_cfg import LiftCubeEnvCfg
+
+
+@configclass
+class LiftCubeMimicEnvCfg(LiftCubeEnvCfg, MimicEnvCfg):
+    """
+    Configuration for the lift cube task with mimic environment.
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.datagen_config.name = "lift_cube_leisaac_task_v0"
+        self.datagen_config.generation_guarantee = True
+        self.datagen_config.generation_keep_failed = True
+        self.datagen_config.generation_num_trials = 10
+        self.datagen_config.generation_select_src_per_subtask = True
+        self.datagen_config.generation_transform_first_robot_pose = False
+        self.datagen_config.generation_interpolate_from_last_target_pose = True
+        self.datagen_config.generation_relative = True
+        self.datagen_config.max_num_failures = 25
+        self.datagen_config.seed = 42
+
+        subtask_configs = []
+        """
+        subtask: pick_cube -> lift it up
+        """
+        subtask_configs.append(
+            SubTaskConfig(
+                # Each subtask involves manipulation with respect to a single object frame.
+                object_ref="cube",
+                # This key corresponds to the binary indicator in "datagen_info" that signals
+                # when this subtask is finished (e.g., on a 0 to 1 edge).
+                subtask_term_signal="pick_cube",
+                # Specifies time offsets for data generation when splitting a trajectory into
+                # subtask segments. Random offsets are added to the termination boundary.
+                subtask_term_offset_range=(10, 20),
+                # Selection strategy for the source subtask segment during data generation
+                selection_strategy="nearest_neighbor_object",
+                # Optional parameters for the selection strategy function
+                selection_strategy_kwargs={"nn_k": 3},
+                # Amount of action noise to apply during this subtask
+                action_noise=0.03,
+                # Number of interpolation steps to bridge to this subtask segment
+                num_interpolation_steps=5,
+                # Additional fixed steps for the robot to reach the necessary pose
+                num_fixed_steps=0,
+                # If True, apply action noise during the interpolation phase and execution
+                apply_noise_during_interpolation=False,
+                description="Pick cube",
+                next_subtask_description="Lift cube",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref=None,
+                subtask_term_signal=None,
+                subtask_term_offset_range=(0, 0),
+                selection_strategy="random",
+                selection_strategy_kwargs={},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+            )
+        )
+        self.subtask_configs["so101_follower"] = subtask_configs

--- a/source/leisaac/leisaac/tasks/lift_cube/mdp/__init__.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/mdp/__init__.py
@@ -1,3 +1,4 @@
 from isaaclab.envs.mdp import *
 
 from .terminations import *
+from .observations import *

--- a/source/leisaac/leisaac/tasks/lift_cube/mdp/observations.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/mdp/observations.py
@@ -1,0 +1,19 @@
+import torch
+
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import FrameTransformer
+from isaaclab.envs import ManagerBasedRLEnv
+import isaaclab.utils.math as PoseUtils
+
+
+def ee_frame_state(env: ManagerBasedRLEnv, ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"), robot_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    robot = env.scene[robot_cfg.name]
+    robot_root_pos, robot_root_quat = robot.data.root_pos_w, robot.data.root_quat_w
+    ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
+    ee_frame_pos, ee_frame_quat = ee_frame.data.target_pos_w[:, 0, :], ee_frame.data.target_quat_w[:, 0, :]
+    ee_frame_pos_robot, ee_frame_quat_robot = PoseUtils.subtract_frame_transforms(
+        robot_root_pos, robot_root_quat, ee_frame_pos, ee_frame_quat
+    )
+    ee_frame_state = torch.cat([ee_frame_pos_robot, ee_frame_quat_robot], dim=1)
+
+    return ee_frame_state

--- a/source/leisaac/leisaac/tasks/lift_cube/mdp/observations.py
+++ b/source/leisaac/leisaac/tasks/lift_cube/mdp/observations.py
@@ -7,6 +7,9 @@ import isaaclab.utils.math as PoseUtils
 
 
 def ee_frame_state(env: ManagerBasedRLEnv, ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"), robot_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """
+    Return the state of the end effector frame in the robot coordinate system.
+    """
     robot = env.scene[robot_cfg.name]
     robot_root_pos, robot_root_quat = robot.data.root_pos_w, robot.data.root_quat_w
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]

--- a/source/leisaac/leisaac/tasks/pick_orange/__init__.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/__init__.py
@@ -11,7 +11,7 @@ gym.register(
 
 gym.register(
     id='LeIsaac-SO101-PickOrange-Mimic-v0',
-    entry_point=f"{__name__}.pick_orange_mimic_env:PickOrangMimicEnv",
+    entry_point=f"{__name__}.pick_orange_mimic_env:PickOrangeMimicEnv",
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.pick_orange_mimic_env_cfg:PickOrangeMimicEnvCfg",

--- a/source/leisaac/leisaac/tasks/pick_orange/__init__.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/__init__.py
@@ -8,3 +8,12 @@ gym.register(
         "env_cfg_entry_point": f"{__name__}.pick_orange_env_cfg:PickOrangeEnvCfg",
     },
 )
+
+gym.register(
+    id='LeIsaac-SO101-PickOrange-Mimic-v0',
+    entry_point=f"{__name__}.pick_orange_mimic_env:PickOrangMimicEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.pick_orange_mimic_env_cfg:PickOrangeMimicEnvCfg",
+    },
+)

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env.py
@@ -1,0 +1,12 @@
+import torch
+
+
+from isaaclab.envs import ManagerBasedRLMimicEnv
+
+
+class PickOrangMimicEnv(ManagerBasedRLMimicEnv):
+    """
+    Environment for the pick orange task with mimic environment.
+    """
+
+    pass

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env.py
@@ -1,12 +1,13 @@
 import torch
+from collections.abc import Sequence
+
+from leisaac.enhance.envs.manager_based_rl_leisaac_mimic_env import ManagerBasedRLLeIsaacMimicEnv
 
 
-from isaaclab.envs import ManagerBasedRLMimicEnv
-
-
-class PickOrangMimicEnv(ManagerBasedRLMimicEnv):
+class PickOrangeMimicEnv(ManagerBasedRLLeIsaacMimicEnv):
     """
     Environment for the pick orange task with mimic environment.
     """
 
-    pass
+    def get_subtask_term_signals(self, env_ids: Sequence[int] | None = None) -> dict[str, torch.Tensor]:
+        pass

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
@@ -137,4 +137,4 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 apply_noise_during_interpolation=False,
             )
         )
-        self.subtask_configs["so101"] = subtask_configs
+        self.subtask_configs["so101_follower"] = subtask_configs

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
@@ -1,0 +1,140 @@
+from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
+from isaaclab.utils import configclass
+
+from .pick_orange_env_cfg import PickOrangeEnvCfg
+
+
+@configclass
+class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
+    """
+    Configuration for the pick orange task with mimic environment.
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.datagen_config.name = "pick_orange_leisaac_task_v0"
+        self.datagen_config.generation_guarantee = True
+        self.datagen_config.generation_keep_failed = True
+        self.datagen_config.generation_num_trials = 10
+        self.datagen_config.generation_select_src_per_subtask = True
+        self.datagen_config.generation_transform_first_robot_pose = False
+        self.datagen_config.generation_interpolate_from_last_target_pose = True
+        self.datagen_config.generation_relative = True
+        self.datagen_config.max_num_failures = 25
+        self.datagen_config.seed = 42
+
+        subtask_configs = []
+        """
+        subtask: pick_orange001 -> put_orange001_to_plate -> pick_orange002 -> put_orange002_to_plate -> pick_orange003 -> put_orange003_to_plate -> rest robot
+        """
+        subtask_configs.append(
+            SubTaskConfig(
+                # Each subtask involves manipulation with respect to a single object frame.
+                object_ref="Orange001",
+                # This key corresponds to the binary indicator in "datagen_info" that signals
+                # when this subtask is finished (e.g., on a 0 to 1 edge).
+                subtask_term_signal="pick_orange001",
+                # Specifies time offsets for data generation when splitting a trajectory into
+                # subtask segments. Random offsets are added to the termination boundary.
+                subtask_term_offset_range=(10, 20),
+                # Selection strategy for the source subtask segment during data generation
+                selection_strategy="nearest_neighbor_object",
+                # Optional parameters for the selection strategy function
+                selection_strategy_kwargs={"nn_k": 3},
+                # Amount of action noise to apply during this subtask
+                action_noise=0.03,
+                # Number of interpolation steps to bridge to this subtask segment
+                num_interpolation_steps=5,
+                # Additional fixed steps for the robot to reach the necessary pose
+                num_fixed_steps=0,
+                # If True, apply action noise during the interpolation phase and execution
+                apply_noise_during_interpolation=False,
+                description="Pick Orange001",
+                next_subtask_description="Put Orange001 to plate",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref="Plate",
+                subtask_term_signal="put_orange001_to_plate",
+                subtask_term_offset_range=(10, 20),
+                selection_strategy="nearest_neighbor_object",
+                selection_strategy_kwargs={"nn_k": 3},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+                next_subtask_description="Pick Orange002",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref="Orange002",
+                subtask_term_signal="pick_orange002",
+                subtask_term_offset_range=(10, 20),
+                selection_strategy="nearest_neighbor_object",
+                selection_strategy_kwargs={"nn_k": 3},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+                next_subtask_description="Put Orange002 to plate",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref="Plate",
+                subtask_term_signal="put_orange002_to_plate",
+                subtask_term_offset_range=(10, 20),
+                selection_strategy="nearest_neighbor_object",
+                selection_strategy_kwargs={"nn_k": 3},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+                next_subtask_description="Pick Orange003",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref="Orange003",
+                subtask_term_signal="pick_orange003",
+                subtask_term_offset_range=(10, 20),
+                selection_strategy="nearest_neighbor_object",
+                selection_strategy_kwargs={"nn_k": 3},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+                next_subtask_description="Put Orange003 to plate",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref="Plate",
+                subtask_term_signal="put_orange003_to_plate",
+                subtask_term_offset_range=(10, 20),
+                selection_strategy="nearest_neighbor_object",
+                selection_strategy_kwargs={"nn_k": 3},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+                next_subtask_description="Rest robot",
+            )
+        )
+        subtask_configs.append(
+            SubTaskConfig(
+                object_ref=None,
+                subtask_term_signal="rest_robot",
+                subtask_term_offset_range=(0, 0),
+                selection_strategy="random",
+                selection_strategy_kwargs={},
+                action_noise=0.03,
+                num_interpolation_steps=5,
+                num_fixed_steps=0,
+                apply_noise_during_interpolation=False,
+            )
+        )
+        self.subtask_configs["so101"] = subtask_configs


### PR DESCRIPTION
1. mimicgen pipeline support: mimic/annotate_demos, mimic/generate_dataset.
2. eef_action conversion: joint_to_ik control and ik_to_joint control.
3. mimicgen example: LeIsaac-SO101-LiftCube-Mimic-v0.
4. support different replay mode: action and state.
5. fix isaaclab version to v2.1.1.
6. random seed when teleoperation.
7. fix background color bug in digital_env.
8. temp file for mimic-pick-orange.