### PR TITLE
mimic-gen example: pick orange.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ We provide an example USD asset—a kitchen scene. Please download related scene
 |----------------------|------------------------------------|------------------------------------------------------------------------------------------|
 | Kitchen with Orange  | Example kitchen scene with oranges | [Download](https://github.com/LightwheelAI/leisaac/releases/tag/v0.1.0)                  |
 | Lightwheel Toyroom   | Modern room with many toys         | [Download](https://github.com/LightwheelAI/leisaac/releases/tag/v0.1.1)                  |
+| Table with Cube      | Simple table with one cube         | [Download](https://github.com/LightwheelAI/leisaac/releases/tag/v0.1.2)                  |
 
 
 > [!TIP] 
@@ -261,6 +262,77 @@ pip install pyzmq
 
 > [!IMPORTANT]
 > For service-based policies, you must start the corresponding service before running inference. For example, with GR00T, you need to launch the GR00T N1.5 inference server first. You can refer to the [GR00T evaluation documentation](https://github.com/NVIDIA/Isaac-GR00T?tab=readme-ov-file#4-evaluation) for detailed instructions.
+
+
+## Extra Feature ✨
+
+We also provide some additional features. You can refer to the following instructions to try them out.
+
+<details>
+<summary><strong>DigitalTwin Env: Make Sim2Real Simple</strong></summary><p></p>
+
+Inspired by the greenscreening functionality from [SIMPLER](https://simpler-env.github.io/) and [ManiSkill](https://github.com/haosulab/ManiSkill), we have implemented DigitalTwin Env. This feature allows you to replace the background in simulation environments with real background images while preserving the foreground elements such as robotic arms and interactive objects. This approach significantly reduces the gap between simulation and reality, enabling better sim2real transfer.
+
+To use this feature, simply create a task configuration class that inherits from `ManagerBasedRLDigitalTwinEnvCfg` and launch it through the corresponding environment. In the configuration class, you can specify relevant parameters including overlay_mode, background images path, and foreground environment components to preserve. 
+
+For usage examples, please refer to the sample task: [LiftCubeDigitalTwinEnvCfg](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py).
+
+</details>
+
+<details>
+<summary><strong>MimicGen Env: Generate Data From Demonstrations</strong></summary><p></p>
+
+We have integrated [IsaacLab MimicGen](https://isaac-sim.github.io/IsaacLab/main/source/overview/teleop_imitation.html), a powerful feature that automatically generates additional demonstrations from expert demonstrations.
+
+To use this functionality, you first need to record some demonstrations. Recording scripts can be referenced from the instructions above. (Below we use the MimicGen for the `LeIsaac-SO101-LiftCube-v0` task as an example).
+
+>[!NOTE] 
+> Pay attention to the `input_file` and `output_file` parameters in the following scripts. Typically, the `output_file` from the previous script becomes the `input_file` for the next script.
+
+Since MimicGen requires trajectory generalization based on end-effector pose and object pose, we first convert joint-position-based action data to IK-based action data. The conversion process is as follows, where `input_file` specifies the collected demonstration data:
+
+```shell
+python scripts/mimic/eef_action_process.py \
+    --input_file ./datasets/mimic-lift-cube-example.hdf5 \
+    --output_file ./datasets/processed_mimic-lift-cube-example.hdf5 \
+    --to_ik --headless
+```
+
+Next, we perform sub-task annotation based on the converted action data. Annotation can be done in two ways: automatic and manual. If you want to use automatic annotation, please add the `--auto` startup option.
+
+```shell
+python scripts/mimic/annotate_demos.py \
+    --device cuda \
+    --task LeIsaac-SO101-LiftCube-Mimic-v0 \
+    --input_file ./datasets/processed_mimic-lift-cube-example.hdf5 \
+    --output_file ./datasets/annotated_mimic-lift-cube-example.hdf5 \
+    --enable_cameras
+```
+
+After annotation is complete, we can proceed with data generation. The generation process is as follows:
+
+```shell
+python scripts/mimic/generate_dataset.py \
+    --device cuda \
+    --num_envs 1 \
+    --generation_num_trials 10 \
+    --input_file ./datasets/annotated_mimic-lift-cube-example.hdf5 \
+    --output_file ./datasets/generated_mimic-lift-cube-example.hdf5 \
+    --enable_cameras
+```
+
+After obtaining the generated data, we also provide a conversion script to transform it from IK-based action data back to joint-position-based action data, as follows:
+
+```shell
+python scripts/mimic/eef_action_process.py \
+    --input_file ./datasets/generated_mimic-lift-cube-example.hdf5 \
+    --output_file ./datasets/final_generated_mimic-lift-cube-example.hdf5 \
+    --to_joint --headless
+```
+
+Finally, you can use replay to view the effects of the generated data. It's worth noting that due to the inherent randomness in IsaacLab simulation, the replay performance may vary.
+
+</details>
 
 ## Acknowledgements 🙏
 

--- a/source/leisaac/leisaac/tasks/pick_orange/mdp/__init__.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/mdp/__init__.py
@@ -2,3 +2,4 @@ from isaaclab.envs.mdp import *
 from leisaac.enhance.envs.mdp import *
 
 from .terminations import *
+from .observations import *

--- a/source/leisaac/leisaac/tasks/pick_orange/mdp/__init__.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/mdp/__init__.py
@@ -1,3 +1,4 @@
 from isaaclab.envs.mdp import *
+from leisaac.enhance.envs.mdp import *
 
 from .terminations import *

--- a/source/leisaac/leisaac/tasks/pick_orange/mdp/observations.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/mdp/observations.py
@@ -1,0 +1,63 @@
+import torch
+
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import FrameTransformer
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+
+
+def orange_grasped(
+        env: ManagerBasedRLEnv,
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("Orange001"),
+        diff_threshold: float = 0.05,
+        grasp_threshold: float = 0.60) -> torch.Tensor:
+    """Check if an object(orange) is grasped by the specified robot."""
+    robot: Articulation = env.scene[robot_cfg.name]
+    ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+
+    object_pos = object.data.root_pos_w
+    end_effector_pos = ee_frame.data.target_pos_w[:, 1, :]
+    pos_diff = torch.linalg.vector_norm(object_pos - end_effector_pos, dim=1)
+
+    grasped = torch.logical_and(pos_diff < diff_threshold, robot.data.joint_pos[:, -1] < grasp_threshold)
+
+    return grasped
+
+
+def put_orange_to_plate(
+        env: ManagerBasedRLEnv,
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("Orange001"),
+        plate_cfg: SceneEntityCfg = SceneEntityCfg("Plate"),
+        x_range: tuple[float, float] = (-0.10, 0.10),
+        y_range: tuple[float, float] = (-0.10, 0.10),
+        diff_threshold: float = 0.05,
+        grasp_threshold: float = 0.60,
+) -> torch.Tensor:
+    """Check if an object(orange) is placed on the specified plate."""
+    robot: Articulation = env.scene[robot_cfg.name]
+    ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
+    orange: RigidObject = env.scene[object_cfg.name]
+    plate: RigidObject = env.scene[plate_cfg.name]
+
+    plate_x, plate_y = plate.data.root_pos_w[:, 0], plate.data.root_pos_w[:, 1]
+    orange_x, orange_y = orange.data.root_pos_w[:, 0], orange.data.root_pos_w[:, 1]
+    orange_in_plate_x = torch.logical_and(orange_x < plate_x + x_range[1], orange_x > plate_x + x_range[0])
+    orange_in_plate_y = torch.logical_and(orange_y < plate_y + y_range[1], orange_y > plate_y + y_range[0])
+    orange_in_plate = torch.logical_and(orange_in_plate_x, orange_in_plate_y)
+
+    end_effector_pos = ee_frame.data.target_pos_w[:, 1, :]
+    orange_pos = orange.data.root_pos_w
+    pos_diff = torch.linalg.vector_norm(orange_pos - end_effector_pos, dim=1)
+    ee_near_to_orange = pos_diff < diff_threshold
+
+    gripper_open = robot.data.joint_pos[:, -1] > grasp_threshold
+
+    placed = torch.logical_and(orange_in_plate, ee_near_to_orange)
+    placed = torch.logical_and(placed, gripper_open)
+
+    return placed

--- a/source/leisaac/leisaac/tasks/pick_orange/mdp/terminations.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/mdp/terminations.py
@@ -58,7 +58,4 @@ def task_done(
     joint_names = env.scene["robot"].data.joint_names
     done = torch.logical_and(done, is_so101_at_rest_pose(joint_pos, joint_names))
 
-    if done.any():
-        print("Task completed!")
-
     return done

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_env_cfg.py
@@ -12,7 +12,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
-from isaaclab.sensors import TiledCameraCfg
+from isaaclab.sensors import TiledCameraCfg, FrameTransformerCfg, OffsetCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
 
@@ -32,6 +32,15 @@ class PickOrangeSceneCfg(InteractiveSceneCfg):
     scene: AssetBaseCfg = KITCHEN_WITH_ORANGE_CFG.replace(prim_path="{ENV_REGEX_NS}/Scene")
 
     robot: ArticulationCfg = SO101_FOLLOWER_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    ee_frame: FrameTransformerCfg = FrameTransformerCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/base",
+        debug_vis=False,
+        target_frames=[
+            FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/gripper", name="gripper"),
+            FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/jaw", name="jaw", offset=OffsetCfg(pos=(-0.021, -0.070, 0.02)))
+        ]
+    )
 
     wrist: TiledCameraCfg = TiledCameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/gripper/wrist_camera",
@@ -100,6 +109,8 @@ class ObservationsCfg:
         actions = ObsTerm(func=mdp.last_action)
         wrist = ObsTerm(func=mdp.image, params={"sensor_cfg": SceneEntityCfg("wrist"), "data_type": "rgb", "normalize": False})
         front = ObsTerm(func=mdp.image, params={"sensor_cfg": SceneEntityCfg("front"), "data_type": "rgb", "normalize": False})
+        ee_frame_state = ObsTerm(func=mdp.ee_frame_state, params={"ee_frame_cfg": SceneEntityCfg("ee_frame"), "robot_cfg": SceneEntityCfg("robot")})
+        joint_pos_target = ObsTerm(func=mdp.joint_pos_target, params={"asset_cfg": SceneEntityCfg("robot")})
 
         def __post_init__(self):
             self.enable_corruption = True
@@ -152,18 +163,20 @@ class PickOrangeEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.physx.friction_correlation_distance = 0.00625
         self.sim.render.enable_translucency = True
 
+        self.scene.ee_frame.visualizer_cfg.markers['frame'].scale = (0.05, 0.05, 0.05)
+
         parse_usd_and_create_subassets(KITCHEN_WITH_ORANGE_USD_PATH, self, specific_name_list=['Orange001', 'Orange002', 'Orange003', 'Plate'])
 
         domain_randomization(self, random_options=[
-            randomize_object_uniform("Orange001", pose_range={"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (0.0, 0.0)}),
-            randomize_object_uniform("Orange002", pose_range={"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (0.0, 0.0)}),
-            randomize_object_uniform("Orange003", pose_range={"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (0.0, 0.0)}),
-            randomize_object_uniform("Plate", pose_range={"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (0.0, 0.0)}),
+            randomize_object_uniform("Orange001", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+            randomize_object_uniform("Orange002", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+            randomize_object_uniform("Orange003", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+            randomize_object_uniform("Plate", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
             randomize_camera_uniform("front", pose_range={
-                "x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (-0.05, 0.05),
-                "roll": (-5 * torch.pi / 180, 5 * torch.pi / 180),
-                "pitch": (-5 * torch.pi / 180, 5 * torch.pi / 180),
-                "yaw": (-5 * torch.pi / 180, 5 * torch.pi / 180)}, convention="ros"),
+                "x": (-0.025, 0.025), "y": (-0.025, 0.025), "z": (-0.025, 0.025),
+                "roll": (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180),
+                "pitch": (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180),
+                "yaw": (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180)}, convention="ros"),
         ])
 
     def use_teleop_device(self, teleop_device) -> None:

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_env_cfg.py
@@ -116,8 +116,23 @@ class ObservationsCfg:
             self.enable_corruption = True
             self.concatenate_terms = False
 
+    @configclass
+    class SubtaskCfg(ObsGroup):
+        """Observations for subtask group."""
+        pick_orange001 = ObsTerm(func=mdp.orange_grasped, params={"object_cfg": SceneEntityCfg("Orange001")})
+        put_orange001_to_plate = ObsTerm(func=mdp.put_orange_to_plate, params={"object_cfg": SceneEntityCfg("Orange001"), "plate_cfg": SceneEntityCfg("Plate")})
+        pick_orange002 = ObsTerm(func=mdp.orange_grasped, params={"object_cfg": SceneEntityCfg("Orange002")})
+        put_orange002_to_plate = ObsTerm(func=mdp.put_orange_to_plate, params={"object_cfg": SceneEntityCfg("Orange002"), "plate_cfg": SceneEntityCfg("Plate")})
+        pick_orange003 = ObsTerm(func=mdp.orange_grasped, params={"object_cfg": SceneEntityCfg("Orange003")})
+        put_orange003_to_plate = ObsTerm(func=mdp.put_orange_to_plate, params={"object_cfg": SceneEntityCfg("Orange003"), "plate_cfg": SceneEntityCfg("Plate")})
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = False
+
     # observation groups
     policy: PolicyCfg = PolicyCfg()
+    subtask_terms: SubtaskCfg = SubtaskCfg()
 
 
 @configclass

--- a/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/pick_orange/pick_orange_mimic_env_cfg.py
@@ -43,7 +43,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 # Optional parameters for the selection strategy function
                 selection_strategy_kwargs={"nn_k": 3},
                 # Amount of action noise to apply during this subtask
-                action_noise=0.03,
+                action_noise=0.003,
                 # Number of interpolation steps to bridge to this subtask segment
                 num_interpolation_steps=5,
                 # Additional fixed steps for the robot to reach the necessary pose
@@ -61,7 +61,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(10, 20),
                 selection_strategy="nearest_neighbor_object",
                 selection_strategy_kwargs={"nn_k": 3},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,
@@ -75,7 +75,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(10, 20),
                 selection_strategy="nearest_neighbor_object",
                 selection_strategy_kwargs={"nn_k": 3},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,
@@ -89,7 +89,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(10, 20),
                 selection_strategy="nearest_neighbor_object",
                 selection_strategy_kwargs={"nn_k": 3},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,
@@ -103,7 +103,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(10, 20),
                 selection_strategy="nearest_neighbor_object",
                 selection_strategy_kwargs={"nn_k": 3},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,
@@ -117,7 +117,7 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
                 subtask_term_offset_range=(10, 20),
                 selection_strategy="nearest_neighbor_object",
                 selection_strategy_kwargs={"nn_k": 3},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,
@@ -127,11 +127,11 @@ class PickOrangeMimicEnvCfg(PickOrangeEnvCfg, MimicEnvCfg):
         subtask_configs.append(
             SubTaskConfig(
                 object_ref=None,
-                subtask_term_signal="rest_robot",
+                subtask_term_signal=None,
                 subtask_term_offset_range=(0, 0),
                 selection_strategy="random",
                 selection_strategy_kwargs={},
-                action_noise=0.03,
+                action_noise=0.003,
                 num_interpolation_steps=5,
                 num_fixed_steps=0,
                 apply_noise_during_interpolation=False,


### PR DESCRIPTION
1. support mimic-gen for pick-orange task.
2. readme update: mimicgen-env and digitaltwin-env.