### PR TITLE
fix mismatched array sizes during concatenation after gr00t update.

### DIFF
--- a/docs/docs/resources/available_policy.md
+++ b/docs/docs/resources/available_policy.md
@@ -32,7 +32,7 @@ python scripts/evaluation/policy_inference.py \
 ```
 
 :::tip
-target commit: https://github.com/NVIDIA/Isaac-GR00T/commit/b211007ed6698e6642d2fd7679dabab1d97e9e6c
+target commit: https://github.com/NVIDIA/Isaac-GR00T/commit/4af2b622892f7dcb5aae5a3fb70bcb02dc217b96
 :::
 
 ## Lerobot official policy

--- a/source/leisaac/leisaac/policy/service_policy_clients.py
+++ b/source/leisaac/leisaac/policy/service_policy_clients.py
@@ -17,7 +17,7 @@ from leisaac.utils.constant import SINGLE_ARM_JOINT_NAMES
 class Gr00tServicePolicyClient(ZMQServicePolicy):
     """
     Service policy client for GR00T N1.5: https://github.com/NVIDIA/Isaac-GR00T
-    Target Commit: https://github.com/NVIDIA/Isaac-GR00T/commit/b211007ed6698e6642d2fd7679dabab1d97e9e6c
+    Target Commit: https://github.com/NVIDIA/Isaac-GR00T/commit/4af2b622892f7dcb5aae5a3fb70bcb02dc217b96
     """
 
     def __init__(


### PR DESCRIPTION
Running policy_inference.py produced the following error:
```
Traceback (most recent call last):
  File "/home/gene/leisaac/scripts/evaluation/policy_inference.py", line 240, in <module>
    main()
  File "/home/gene/leisaac/scripts/evaluation/policy_inference.py", line 207, in main
    actions = policy.get_action(obs_dict).to(env.device)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gene/leisaac/source/leisaac/leisaac/policy/service_policy_clients.py", line 80, in get_action
    concat_action = np.concatenate(
                    ^^^^^^^^^^^^^^^
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 3 dimension(s)
```