### PR TITLE
Add CLI support to IsaacLab to LeRobot converter

### DIFF
--- a/source/leisaac/pyproject.toml
+++ b/source/leisaac/pyproject.toml
@@ -22,6 +22,7 @@ requires-python = ">=3.10"
 dependencies = [
     "psutil",
     "pyserial",
+    "typer",
     "deepdiff",
     "feetech-servo-sdk",
     "pygame>=2.5.1,<2.7.0"


### PR DESCRIPTION
**Summary:**
Convert the isaaclab2lerobot.py script to use Typer CLI, making it configurable via command-line arguments instead of hardcoded parameters. to fix #99 #98 
**Changes:**
1. CLI interface: Added Typer-based CLI with configurable options for all parameters (repo_id, robot_type, fps, hdf5_root, hdf5_files, task, push_to_hub)
2. Task field: Include task in frame data instead of passing as separate parameter to add_frame(), to support lerobot 0.4.0
3. HDF5 files handling: Support comma-separated file list or default to dataset.hdf5 in hdf5_root

**Verification:**
Tested locally: Confirmed successful conversion of HDF5 to LeRobot format.