### PR TITLE
Fix AttributeError in teleop_se3_agent caused by missing display_controls

### DIFF
--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -290,7 +290,7 @@ def main():  # noqa: C901
 
     teleop_interface.add_callback("R", reset_recording_instance)
     teleop_interface.add_callback("N", reset_task_success)
-    teleop_interface.display_controls()
+    teleop_interface._display_controls()
     rate_limiter = RateLimiter(args_cli.step_hz)
 
     # reset environment


### PR DESCRIPTION
### Problem
Running `teleop_se3_agent.py` raises the following error:

AttributeError: 'SO101Keyboard' object has no attribute 'display_controls'
Did you mean: '_display_controls'?

This line was introduced in commit `961121d`.

I’m not sure whether this behavior is due to a bug or changes introduced by differences in the environment or versions, as I merged the environment from another project during setup.

### Fix
- Replace the incorrect `display_controls()` call with `_display_controls()`

### Note
I am also working on a data auto-generation feature for leisaac and it's nearly complete.
That work is **not included** in this PR and will be submitted separately in a future PR once it is ready.