### PR TITLE
Decouple LeRobot --- Solves issues with several dependencies

### DIFF
--- a/source/leisaac/leisaac/enhance/datasets/lerobot_dataset_handler.py
+++ b/source/leisaac/leisaac/enhance/datasets/lerobot_dataset_handler.py
@@ -3,12 +3,14 @@ import copy
 from isaaclab.utils import configclass
 from isaaclab.utils.datasets.dataset_file_handler_base import DatasetFileHandlerBase
 from isaaclab.utils.datasets.episode_data import EpisodeData
+
 try:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
-    HAS_LEROBOT = True
+
+    _HAS_LEROBOT = True
 except ImportError:
-    HAS_LEROBOT = False
-    LeRobotDataset = None # Placeholder
+    _HAS_LEROBOT = False
+    LeRobotDataset = None  # Placeholder
 
 
 @configclass
@@ -35,7 +37,7 @@ class LeRobotDatasetHandler(DatasetFileHandlerBase):
         self._env_args = {}
 
     def create(self, file_path: str, env_name: str = None, resume: bool = False):
-        if HAS_LEROBOT:
+        if _HAS_LEROBOT:
             # Original LeRobot logic
             if resume:
                 self._lerobot_dataset = LeRobotDataset(repo_id=self._cfg.repo_id)
@@ -53,7 +55,7 @@ class LeRobotDatasetHandler(DatasetFileHandlerBase):
 
     def open(self, file_path: str, mode: str = "r"):
         """Opens an existing dataset for reading or appending."""
-        if HAS_LEROBOT:
+        if _HAS_LEROBOT:
             # Standard LeRobot initialization
             self._lerobot_dataset = LeRobotDataset(
                 repo_id=self._cfg.repo_id,
@@ -62,9 +64,7 @@ class LeRobotDatasetHandler(DatasetFileHandlerBase):
             # Decoupled logic: Initialize your custom handler
             # You can use file_path here to load existing metadata
             self._lerobot_dataset = GenericDataRecorder(
-                repo_id=self._cfg.repo_id, 
-                fps=self._cfg.fps, 
-                features=self._cfg.features
+                repo_id=self._cfg.repo_id, fps=self._cfg.fps, features=self._cfg.features
             )
             if mode == "r":
                 self._lerobot_dataset.load_from_disk(file_path)
@@ -99,6 +99,7 @@ class LeRobotDatasetHandler(DatasetFileHandlerBase):
     def get_num_episodes(self) -> int:
         raise NotImplementedError("get_num_episodes is not supported for LeRobotDatasetHandler")
 
+
 # Create a simple fallback recorder if LeRobot is missing
 class GenericDataRecorder:
     def __init__(self, repo_id, fps, features):
@@ -114,6 +115,7 @@ class GenericDataRecorder:
     def save_episode(self, **kwargs):
         # Save to a standard format like pickle or numpy
         import pickle
+
         with open(f"{self.repo_id}_episode.pkl", "wb") as f:
             pickle.dump(self.buffer, f)
         self.buffer = []
@@ -123,6 +125,6 @@ class GenericDataRecorder:
 
     def load_from_disk(self, path):
         # Implementation to load your custom .npz or .json files
-        # This ensures that even without LeRobot, your 'open' method 
+        # This ensures that even without LeRobot, your 'open' method
         # populates the metadata correctly.
-        pass        
+        pass


### PR DESCRIPTION
LeRobot is a continuously evolving project and depending on importing the entire project as dependency to build the dict with the features of the Sim environment is a mistake.

So I created a temporary "Generic" Handler to treat LeRobotDataset as an interface rather than a hard dependency. 

This let users to use the IsaacLab script to create the Conda environment and then install leisaac. If you dont need LeRobot, or just want to run Inference, or wanna use another solution to creating the dataset. This is for you.

`./isaaclab.sh --conda leisaac`

`pip install -e source/leisaac`

`pip install -e source/leisaac[gr00t]`
