### PR TITLE
feat: integrate Elfin S30 + Robotiq 2F-140 into LeIsaac

### DIFF
--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -30,6 +30,8 @@ parser.add_argument(
         "lekiwi-keyboard",
         "lekiwi-gamepad",
         "lekiwi-leader",
+        "s30-keyboard",
+        "s30-gamepad",
     ],
     help="Device for interacting with environment",
 )
@@ -281,10 +283,18 @@ def main():  # noqa: C901
         from leisaac.devices import LeKiwiGamepad
 
         teleop_interface = LeKiwiGamepad(env, sensitivity=args_cli.sensitivity)
+    elif args_cli.teleop_device == "s30-keyboard":
+        from leisaac.devices import S30Keyboard
+
+        teleop_interface = S30Keyboard(env, sensitivity=args_cli.sensitivity)
+    elif args_cli.teleop_device == "s30-gamepad":
+        from leisaac.devices import SO101Gamepad
+
+        teleop_interface = SO101Gamepad(env, sensitivity=args_cli.sensitivity)
     else:
         raise ValueError(
-            f"Invalid device interface '{args_cli.teleop_device}'. Supported: 'keyboard', 'gamepad', 'so101leader',"
-            " 'bi-so101leader', 'lekiwi-keyboard', 'lekiwi-leader', 'lekiwi-gamepad'."
+            f"Invalid device interface '{args_cli.teleop_device}'. Supported: 'keyboard', 'gamepad', 's30-keyboard',"
+            " 's30-gamepad', 'so101leader', 'bi-so101leader', 'lekiwi-keyboard', 'lekiwi-leader', 'lekiwi-gamepad'."
         )
 
     # add teleoperation key for env reset

--- a/source/leisaac/leisaac/assets/robots/elfin_s30.py
+++ b/source/leisaac/leisaac/assets/robots/elfin_s30.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+
+import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets.articulation import ArticulationCfg
+from leisaac.utils.constant import ASSETS_ROOT
+
+"""Configuration for the Elfin S30 arm + Robotiq 2F-140 gripper."""
+
+S30_ASSET_PATH = str(Path(ASSETS_ROOT) / "robots" / "elfin_s30" / "S30.usd")
+
+S30_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=S30_ASSET_PATH,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=True,
+            solver_position_iteration_count=8,
+            solver_velocity_iteration_count=4,
+            fix_root_link=True,
+        ),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(2.2, -1.5, 0.89),
+        rot=(0.0, 0.0, 0.0, 1.0),
+        joint_pos={
+            "joint1": 0.0,
+            "joint2": -1.5708,   # -90 deg
+            "joint3": 1.5708,    # +90 deg
+            "joint4": 0.0,
+            "joint5": -1.5708,   # -90 deg
+            "joint6": 0.0,
+            "finger_joint": 0.0,
+        },
+    ),
+    actuators={
+        "elfin-arm": ImplicitActuatorCfg(
+            joint_names_expr=["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"],
+            effort_limit_sim=350.0,
+            velocity_limit_sim=1.57,
+            stiffness=349.0,
+            damping=34.9,
+        ),
+        "robotiq-finger": ImplicitActuatorCfg(
+            joint_names_expr=["finger_joint"],
+            effort_limit_sim=50.0,
+            velocity_limit_sim=0.5,
+            stiffness=800.0,
+            damping=40.0,
+        ),
+        # ActionGraph drove ONLY right_outer_knuckle_joint at the same 0-45° as finger_joint.
+        # Ratio = +1 (same direction): both joints share identical position targets.
+        # All other 4-bar joints (inner_knuckle, outer_finger, inner_finger) are
+        # handled by PhysX gear/mimic constraints embedded in physics_edit.usd.
+        # inner_finger_pad_joint is NVIDIA-specific (absent from standard URDF mimic list),
+        # so it has no PhysX constraint and must be tracked here with ratio = -1.
+        "robotiq-mimic": ImplicitActuatorCfg(
+            joint_names_expr=[
+                "right_outer_knuckle_joint",
+                "left_inner_finger_pad_joint",
+                "right_inner_finger_pad_joint",
+            ],
+            effort_limit_sim=50.0,
+            velocity_limit_sim=0.5,
+            stiffness=800.0,
+            damping=40.0,
+        ),
+    },
+    soft_joint_pos_limit_factor=1.0,
+)
+
+# Joint limits as stored in USD (degrees).
+# Derived from URDF limits converted to degrees:
+#   joint1: ±6.28 rad  → ±360°
+#   joint2: -3.3158 ~ 0.1745 rad → -190° ~ 10°
+#   joint3: ±2.9319 rad → ±168°
+#   joint4/5/6: ±6.28 rad → ±360°
+#   finger_joint: 0 ~ 45° (Robotiq 2F-140 opening angle)
+S30_USD_JOINT_LIMITS = {
+    "joint1":       (-360.0, 360.0),
+    "joint2":       (-190.0,  10.0),
+    "joint3":       (-168.0, 168.0),
+    "joint4":       (-360.0, 360.0),
+    "joint5":       (-360.0, 360.0),
+    "joint6":       (-360.0, 360.0),
+    "finger_joint": (   0.0,  45.0),
+}
+
+# Motor limits — the angle range (degrees) accepted by the TCP/IP SDK.
+# For S30 the SDK takes joint angles directly in degrees, so limits equal USD limits.
+S30_MOTOR_LIMITS = {
+    "joint1":       (-360.0, 360.0),
+    "joint2":       (-190.0,  10.0),
+    "joint3":       (-168.0, 168.0),
+    "joint4":       (-360.0, 360.0),
+    "joint5":       (-360.0, 360.0),
+    "joint6":       (-360.0, 360.0),
+    "finger_joint": (   0.0,  45.0),
+}
+
+# Rest pose range (degrees) used to detect whether the arm has returned to home.
+# Centred on the init_state joint positions converted to degrees.
+S30_REST_POSE_RANGE = {
+    "joint1":       (  0.0 - 30.0,   0.0 + 30.0),
+    "joint2":       (-90.0 - 30.0, -90.0 + 30.0),
+    "joint3":       ( 90.0 - 30.0,  90.0 + 30.0),
+    "joint4":       (  0.0 - 30.0,   0.0 + 30.0),
+    "joint5":       (-90.0 - 30.0, -90.0 + 30.0),
+    "joint6":       (  0.0 - 30.0,   0.0 + 30.0),
+    "finger_joint": (  0.0,          15.0),          # nearly open counts as rest
+}

--- a/source/leisaac/leisaac/devices/__init__.py
+++ b/source/leisaac/leisaac/devices/__init__.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .device_base import DeviceBase
     from .gamepad import SO101Gamepad
-    from .keyboard import SO101Keyboard
+    from .keyboard import S30Keyboard, SO101Keyboard
     from .lekiwi import LeKiwiGamepad, LeKiwiKeyboard, LeKiwiLeader
     from .lerobot import BiSO101Leader, SO101Leader, SO101LeaderRemote
 
 __all__ = [
     "DeviceBase",
+    "S30Keyboard",
     "SO101Gamepad",
     "SO101Keyboard",
     "LeKiwiGamepad",
@@ -22,6 +23,7 @@ __all__ = [
 
 _LAZY_IMPORTS = {
     "DeviceBase": (".device_base", "DeviceBase"),
+    "S30Keyboard": (".keyboard", "S30Keyboard"),
     "SO101Gamepad": (".gamepad", "SO101Gamepad"),
     "SO101Keyboard": (".keyboard", "SO101Keyboard"),
     "LeKiwiGamepad": (".lekiwi", "LeKiwiGamepad"),

--- a/source/leisaac/leisaac/devices/action_process.py
+++ b/source/leisaac/leisaac/devices/action_process.py
@@ -8,7 +8,18 @@ from leisaac.assets.robots.lerobot import SO101_FOLLOWER_USD_JOINT_LIMLITS
 
 def init_action_cfg(action_cfg, device):
     """SO101 Follower action configuration: arm_action and gripper_action"""
-    if device in ["so101leader", "lekiwi-leader"]:
+    if device in ["s30"]:
+        action_cfg.arm_action = mdp.JointPositionActionCfg(
+            asset_name="robot",
+            joint_names=["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"],
+            scale=1.0,
+        )
+        action_cfg.gripper_action = mdp.JointPositionActionCfg(
+            asset_name="robot",
+            joint_names=["finger_joint"],
+            scale=1.0,
+        )
+    elif device in ["so101leader", "lekiwi-leader"]:
         action_cfg.arm_action = mdp.JointPositionActionCfg(
             asset_name="robot",
             joint_names=["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll"],
@@ -17,6 +28,18 @@ def init_action_cfg(action_cfg, device):
         action_cfg.gripper_action = mdp.JointPositionActionCfg(
             asset_name="robot",
             joint_names=["gripper"],
+            scale=1.0,
+        )
+    elif device in ["s30-keyboard", "s30-gamepad"]:
+        action_cfg.arm_action = mdp.DifferentialInverseKinematicsActionCfg(
+            asset_name="robot",
+            joint_names=["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"],
+            body_name="elfin_link6",
+            controller=mdp.DifferentialIKControllerCfg(command_type="pose", ik_method="dls", use_relative_mode=True),
+        )
+        action_cfg.gripper_action = mdp.RelativeJointPositionActionCfg(
+            asset_name="robot",
+            joint_names=["finger_joint"],
             scale=1.0,
         )
     elif device in ["keyboard", "gamepad", "lekiwi-keyboard", "lekiwi-gamepad"]:
@@ -169,6 +192,9 @@ def preprocess_device_action(action: dict[str, Any], teleop_device) -> torch.Ten
         processed_action = convert_action_from_so101_leader(
             action["joint_state"], action["motor_limits"], teleop_device
         )
+    elif action.get("s30-keyboard") is not None or action.get("s30-gamepad") is not None:
+        processed_action = torch.zeros(teleop_device.env.num_envs, 7, device=teleop_device.env.device)
+        processed_action[:, :] = action["joint_state"]
     elif action.get("keyboard") is not None or action.get("gamepad") is not None:
         processed_action = torch.zeros(teleop_device.env.num_envs, 8, device=teleop_device.env.device)
         processed_action[:, :] = action["joint_state"]

--- a/source/leisaac/leisaac/devices/keyboard/__init__.py
+++ b/source/leisaac/leisaac/devices/keyboard/__init__.py
@@ -1,1 +1,2 @@
+from .s30_keyboard import S30Keyboard
 from .so101_keyboard import SO101Keyboard

--- a/source/leisaac/leisaac/devices/keyboard/s30_keyboard.py
+++ b/source/leisaac/leisaac/devices/keyboard/s30_keyboard.py
@@ -1,0 +1,104 @@
+import carb
+import numpy as np
+
+from ..device_base import Device
+
+
+class S30Keyboard(Device):
+    """键盘控制器，用于 S30 + Robotiq 2F-140 机械臂的末端执行器控制。
+
+    发送 SE(3) 增量位姿指令，通过差分逆运动学（DiffIK）驱动 S30 六轴臂，
+    同时独立控制夹爪。
+
+    Key bindings:
+        ============================== ================= =================
+        Description                    Key               Key
+        ============================== ================= =================
+        Forward / Backward              W                 S
+        Left / Right                    A                 D
+        Up / Down                       Q                 E
+        Rotate (Yaw) Left / Right       J                 L
+        Rotate (Pitch) Up / Down        K                 I
+        Gripper Open / Close            U                 O
+        ============================== ================= =================
+
+    Output (7D): [dx, dy, dz, droll, dpitch, dyaw, d_gripper]
+    """
+
+    def __init__(self, env, sensitivity: float = 1.0):
+        super().__init__(env, "s30-keyboard")
+
+        self.pos_sensitivity = 0.03 * sensitivity
+        self.rot_sensitivity = 0.30 * sensitivity
+        self.joint_sensitivity = 0.30 * sensitivity
+
+        self._create_key_bindings()
+
+        # 7D: (dx, dy, dz, droll, dpitch, dyaw, d_gripper)
+        self._delta_action = np.zeros(7)
+
+        self.asset_name = "robot"
+        self.robot_asset = self.env.scene[self.asset_name]
+
+        self.target_frame = "elfin_link6"
+        body_idxs, _ = self.robot_asset.find_bodies(self.target_frame)
+        self.target_frame_idx = body_idxs[0]
+
+    def _add_device_control_description(self):
+        self._display_controls_table.add_row(["W", "forward"])
+        self._display_controls_table.add_row(["S", "backward"])
+        self._display_controls_table.add_row(["A", "left"])
+        self._display_controls_table.add_row(["D", "right"])
+        self._display_controls_table.add_row(["Q", "up"])
+        self._display_controls_table.add_row(["E", "down"])
+        self._display_controls_table.add_row(["J", "rotate_left (yaw)"])
+        self._display_controls_table.add_row(["L", "rotate_right (yaw)"])
+        self._display_controls_table.add_row(["K", "rotate_down (pitch)"])
+        self._display_controls_table.add_row(["I", "rotate_up (pitch)"])
+        self._display_controls_table.add_row(["U", "gripper_open"])
+        self._display_controls_table.add_row(["O", "gripper_close"])
+
+    def get_device_state(self):
+        return self._convert_delta_from_frame(self._delta_action)
+
+    def reset(self):
+        self._delta_action[:] = 0.0
+
+    def _on_keyboard_event(self, event, *args, **kwargs):
+        super()._on_keyboard_event(event, *args, **kwargs)
+        if event.type == carb.input.KeyboardEventType.KEY_PRESS:
+            if event.input.name in self._INPUT_KEY_MAPPING:
+                self._delta_action += self._ACTION_DELTA_MAPPING[self._INPUT_KEY_MAPPING[event.input.name]]
+        if event.type == carb.input.KeyboardEventType.KEY_RELEASE:
+            if event.input.name in self._INPUT_KEY_MAPPING:
+                self._delta_action -= self._ACTION_DELTA_MAPPING[self._INPUT_KEY_MAPPING[event.input.name]]
+
+    def _create_key_bindings(self):
+        self._ACTION_DELTA_MAPPING = {
+            "forward":       np.asarray([0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "backward":      np.asarray([0.0, 0.0,  1.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "left":          np.asarray([-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "right":         np.asarray([ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "up":            np.asarray([0.0,  1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "down":          np.asarray([0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0]) * self.pos_sensitivity,
+            "rotate_left":   np.asarray([0.0, 0.0, 0.0, 0.0, 0.0,  1.0, 0.0]) * self.rot_sensitivity,
+            "rotate_right":  np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0]) * self.rot_sensitivity,
+            "rotate_up":     np.asarray([0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0]) * self.rot_sensitivity,
+            "rotate_down":   np.asarray([0.0, 0.0, 0.0, 0.0,  1.0, 0.0, 0.0]) * self.rot_sensitivity,
+            "gripper_open":  np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  1.0]) * self.joint_sensitivity,
+            "gripper_close": np.asarray([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]) * self.joint_sensitivity,
+        }
+        self._INPUT_KEY_MAPPING = {
+            "W": "forward",
+            "S": "backward",
+            "A": "left",
+            "D": "right",
+            "Q": "up",
+            "E": "down",
+            "J": "rotate_left",
+            "L": "rotate_right",
+            "K": "rotate_down",
+            "I": "rotate_up",
+            "U": "gripper_open",
+            "O": "gripper_close",
+        }

--- a/source/leisaac/leisaac/policy/lerobot/__init__.py
+++ b/source/leisaac/leisaac/policy/lerobot/__init__.py
@@ -20,7 +20,7 @@ def create_module_hierarchy(path: str):
                 setattr(sys.modules[parent_path], parts[i - 1], mod)
 
 
-helpers_path = "lerobot.scripts.server.helpers"
+helpers_path = "lerobot.async_inference.helpers"
 create_module_hierarchy(helpers_path)
 
 fake_lerobot_module = sys.modules[helpers_path]

--- a/source/leisaac/leisaac/policy/lerobot/helpers.py
+++ b/source/leisaac/leisaac/policy/lerobot/helpers.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 import torch
@@ -25,6 +25,7 @@ class RemotePolicyConfig:
     lerobot_features: dict[str, PolicyFeature]
     actions_per_chunk: int
     device: str = "cpu"
+    rename_map: dict = field(default_factory=dict)
 
 
 RawObservation = dict[str, torch.Tensor]

--- a/source/leisaac/leisaac/policy/service_policy_clients.py
+++ b/source/leisaac/leisaac/policy/service_policy_clients.py
@@ -8,7 +8,11 @@ from leisaac.utils.constant import SINGLE_ARM_JOINT_NAMES
 from leisaac.utils.robot_utils import (
     convert_leisaac_action_to_lerobot,
     convert_lerobot_action_to_leisaac,
+    convert_s30_action_to_lerobot,
+    convert_lerobot_action_to_s30,
 )
+
+from leisaac.utils.constant import S30_JOINT_NAMES
 
 from .base import Policy, WebsocketServicePolicy, ZMQServicePolicy
 from .lerobot.helpers import RemotePolicyConfig, TimedObservation
@@ -227,6 +231,13 @@ class LeRobotServicePolicyClient(Policy):
                 "names": [f"{joint_name}.pos" for joint_name in SINGLE_ARM_JOINT_NAMES],
             }
             self.last_action = np.zeros((1, 6))
+        elif task_type == "s30":
+            lerobot_features["observation.state"] = {
+                "dtype": "float32",
+                "shape": (len(S30_JOINT_NAMES),),
+                "names": [f"{joint_name}.pos" for joint_name in S30_JOINT_NAMES],
+            }
+            self.last_action = np.zeros((1, len(S30_JOINT_NAMES)))
         # TODO: add bi-arm support
 
         for camera_key, camera_image_shape in camera_infos.items():
@@ -277,6 +288,10 @@ class LeRobotServicePolicyClient(Policy):
             joint_pos = convert_leisaac_action_to_lerobot(observation_dict["joint_pos"])
             for joint_name in SINGLE_ARM_JOINT_NAMES:
                 raw_observation[f"{joint_name}.pos"] = joint_pos[0, SINGLE_ARM_JOINT_NAMES.index(joint_name)].item()
+        elif self.task_type == "s30":
+            joint_pos = convert_s30_action_to_lerobot(observation_dict["joint_pos"])
+            for idx, joint_name in enumerate(S30_JOINT_NAMES):
+                raw_observation[f"{joint_name}.pos"] = joint_pos[0, idx].item()
         # TODO: add bi-arm support
 
         """
@@ -317,6 +332,12 @@ class LeRobotServicePolicyClient(Policy):
             return None
         return pickle.loads(actions_chunk.data)
 
+    def _lerobot_to_sim(self, action: torch.Tensor) -> np.ndarray:
+        """Convert policy output (LeRobot dataset units) back to Isaac Sim radians."""
+        if self.task_type == "s30":
+            return convert_lerobot_action_to_s30(action)
+        return convert_lerobot_action_to_leisaac(action)
+
     def get_action(self, observation_dict: dict) -> torch.Tensor:
         if not self.skip_send_observation:
             self._send_observation(observation_dict)
@@ -327,7 +348,7 @@ class LeRobotServicePolicyClient(Policy):
 
         action_list = [action.get_action()[None, :] for action in action_chunk]
         concat_action = torch.cat(action_list, dim=0)
-        concat_action = convert_lerobot_action_to_leisaac(concat_action)
+        concat_action = self._lerobot_to_sim(concat_action)
 
         self.last_action = concat_action[-1, :]
         self.skip_send_observation = False

--- a/source/leisaac/leisaac/tasks/s30_pick_orange/__init__.py
+++ b/source/leisaac/leisaac/tasks/s30_pick_orange/__init__.py
@@ -1,0 +1,10 @@
+import gymnasium as gym
+
+gym.register(
+    id="LeIsaac-S30-PickOrange-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.s30_pick_orange_env_cfg:S30PickOrangeEnvCfg",
+    },
+)

--- a/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/__init__.py
+++ b/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/__init__.py
@@ -1,0 +1,3 @@
+from .events import track_robotiq_mimic_joints
+from .terminations import task_done
+from leisaac.tasks.pick_orange.mdp import orange_grasped, put_orange_to_plate

--- a/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/events.py
+++ b/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/events.py
@@ -1,0 +1,77 @@
+"""S30 + Robotiq 2F-140 specific event functions.
+
+Replaces the ActionGraph (removed to avoid eENABLE_DIRECT_GPU_API conflicts).
+
+Robotiq 2F-140 mechanism (USD joint names are authoritative, image of stage tree confirmed):
+
+  Joint structure (10 PhysicsRevolute joints):
+    finger_joint               : 0-45°, main driver (controlled by action manager)
+    right_outer_knuckle_joint  : 0-45°, mirrored by this event (ratio +1, same direction)
+    left_inner_knuckle_joint   : no limit, PhysX gear-constrained
+    right_inner_knuckle_joint  : no limit, PhysX gear-constrained
+    left_outer_finger_joint    : 0-180°, PhysX gear-constrained
+    right_outer_finger_joint   : 0-180°, PhysX gear-constrained
+    left_inner_finger_joint    : no limit, PhysX gear-constrained
+    right_inner_finger_joint   : no limit, PhysX gear-constrained
+    left_inner_finger_pad_joint: -45~+45°, PhysX gear-constrained (no explicit actuator)
+    right_inner_finger_pad_joint:-45~+45°, PhysX gear-constrained (no explicit actuator)
+
+  NOTE: left_inner_finger_pad_joint ≠ left_inner_knuckle_joint — they are distinct
+  joints in the stage.  The ActionGraph drove ONLY finger_joint + right_outer_knuckle_joint
+  (both at ratio +1, 0-45°).  All 4-bar joints are gear-constrained in physics_edit.usd.
+"""
+
+from __future__ import annotations
+
+import torch
+from isaaclab.assets import Articulation
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import SceneEntityCfg
+
+_MIMIC_JOINTS: list[tuple[str, float]] = [
+    # ActionGraph drove both finger_joint and right_outer_knuckle_joint to the SAME
+    # 0-45° value (ratio +1).  The right side joint axis is already defined to close
+    # in the positive direction, matching finger_joint convention.
+    ("right_outer_knuckle_joint",    +1.0),
+    # inner_finger_pad_joint is NVIDIA-specific (not in standard URDF mimic list).
+    # No PhysX gear constraint → must be tracked explicitly.
+    # When finger closes by θ, pad must rotate -θ to stay parallel (range -45~+45°).
+    ("left_inner_finger_pad_joint",  1.0),
+    ("right_inner_finger_pad_joint", 1.0),
+]
+
+_joint_cache: dict[str, tuple[int, list[tuple[int, float]]]] = {}
+
+
+def track_robotiq_mimic_joints(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> None:
+    """Mirror right_outer_knuckle_joint to finger_joint every physics step (ratio +1)."""
+    robot: Articulation = env.scene[asset_cfg.name]
+
+    cache_key = asset_cfg.name
+    if cache_key not in _joint_cache:
+        finger_ids, _ = robot.find_joints("finger_joint")
+        if not finger_ids:
+            return
+        mimic_list: list[tuple[int, float]] = []
+        for joint_name, ratio in _MIMIC_JOINTS:
+            try:
+                ids, _ = robot.find_joints(joint_name)
+                if ids:
+                    mimic_list.append((ids[0], ratio))
+            except ValueError:
+                pass
+        _joint_cache[cache_key] = (finger_ids[0], mimic_list)
+
+    finger_idx, mimic_list = _joint_cache[cache_key]
+    if not mimic_list:
+        return
+
+    finger_pos = robot.data.joint_pos[:, finger_idx]
+    for joint_idx, ratio in mimic_list:
+        robot.set_joint_position_target(
+            (finger_pos * ratio).unsqueeze(-1), joint_ids=[joint_idx]
+        )

--- a/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/terminations.py
+++ b/source/leisaac/leisaac/tasks/s30_pick_orange/mdp/terminations.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import torch
+from isaaclab.assets import RigidObject
+from isaaclab.envs import DirectRLEnv, ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+from leisaac.utils.robot_utils import is_s30_at_rest_pose
+
+
+def task_done(
+    env: ManagerBasedRLEnv | DirectRLEnv,
+    oranges_cfg: list[SceneEntityCfg],
+    plate_cfg: SceneEntityCfg,
+    x_range: tuple[float, float] = (-0.10, 0.10),
+    y_range: tuple[float, float] = (-0.10, 0.10),
+    height_range: tuple[float, float] = (-0.07, 0.07),
+) -> torch.Tensor:
+    """Task-done check for the S30 + Robotiq pick-orange task.
+
+    Identical to the SO101 version except the rest-pose check uses S30 joint names.
+    """
+    done = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+    plate: RigidObject = env.scene[plate_cfg.name]
+    plate_x = plate.data.root_pos_w[:, 0] - env.scene.env_origins[:, 0]
+    plate_y = plate.data.root_pos_w[:, 1] - env.scene.env_origins[:, 1]
+    plate_height = plate.data.root_pos_w[:, 2] - env.scene.env_origins[:, 2]
+
+    for orange_cfg in oranges_cfg:
+        orange: RigidObject = env.scene[orange_cfg.name]
+        orange_x = orange.data.root_pos_w[:, 0] - env.scene.env_origins[:, 0]
+        orange_y = orange.data.root_pos_w[:, 1] - env.scene.env_origins[:, 1]
+        orange_height = orange.data.root_pos_w[:, 2] - env.scene.env_origins[:, 2]
+
+        done = torch.logical_and(done, orange_x < plate_x + x_range[1])
+        done = torch.logical_and(done, orange_x > plate_x + x_range[0])
+        done = torch.logical_and(done, orange_y < plate_y + y_range[1])
+        done = torch.logical_and(done, orange_y > plate_y + y_range[0])
+        done = torch.logical_and(done, orange_height < plate_height + height_range[1])
+        done = torch.logical_and(done, orange_height > plate_height + height_range[0])
+
+    joint_pos = env.scene["robot"].data.joint_pos
+    joint_names = env.scene["robot"].data.joint_names
+    done = torch.logical_and(done, is_s30_at_rest_pose(joint_pos, joint_names))
+
+    return done

--- a/source/leisaac/leisaac/tasks/s30_pick_orange/s30_pick_orange_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/s30_pick_orange/s30_pick_orange_env_cfg.py
@@ -1,0 +1,210 @@
+from typing import Any
+
+import isaaclab.sim as sim_utils
+import torch
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import FrameTransformerCfg, OffsetCfg, TiledCameraCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.datasets.episode_data import EpisodeData
+from leisaac.assets.robots.elfin_s30 import S30_CFG
+from leisaac.assets.scenes.kitchen import (
+    KITCHEN_WITH_ORANGE_CFG,
+    KITCHEN_WITH_ORANGE_USD_PATH,
+)
+from leisaac.enhance.datasets.lerobot_dataset_handler import LeRobotDatasetCfg
+from leisaac.utils.constant import S30_JOINT_NAMES
+from leisaac.utils.domain_randomization import (
+    domain_randomization,
+    randomize_camera_uniform,
+    randomize_object_uniform,
+)
+from leisaac.utils.general_assets import parse_usd_and_create_subassets
+from leisaac.utils.robot_utils import convert_s30_action_to_lerobot
+
+from ..template import SingleArmEventCfg, SingleArmObservationsCfg, SingleArmTaskEnvCfg, SingleArmTerminationsCfg
+from . import mdp as s30_mdp
+
+
+@configclass
+class S30TaskSceneCfg(InteractiveSceneCfg):
+    """Scene configuration for the S30 single-arm task."""
+
+    scene: AssetBaseCfg = KITCHEN_WITH_ORANGE_CFG.replace(prim_path="{ENV_REGEX_NS}/Scene")
+
+    robot: ArticulationCfg = S30_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    # End-effector frame tracker.
+    # elfin_link6 is the last articulation link (rigid body) of the arm.
+    # The gripper prim is an Xform container and NOT a rigid body, so it cannot
+    # be used as a FrameTransformer target.  We attach both frames to elfin_link6
+    # and apply offsets to approximate the gripper centre and finger tip.
+    ee_frame: FrameTransformerCfg = FrameTransformerCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/elfin_base",
+        debug_vis=False,
+        target_frames=[
+            FrameTransformerCfg.FrameCfg(
+                prim_path="{ENV_REGEX_NS}/Robot/elfin_link6",
+                name="gripper",
+                # Offset to Robotiq base (~0.14 m along link6 z-axis after flange)
+                offset=OffsetCfg(pos=(0.0, 0.0, 0.14)),
+            ),
+            FrameTransformerCfg.FrameCfg(
+                prim_path="{ENV_REGEX_NS}/Robot/elfin_link6",
+                name="jaw",
+                # Offset to finger tip (~0.30 m from link6 origin)
+                offset=OffsetCfg(pos=(0.0, 0.0, 0.30)),
+            ),
+        ],
+    )
+
+    # Wrist camera mounted on elfin_link6 (last arm link before gripper)
+    wrist: TiledCameraCfg = TiledCameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/elfin_link6/wrist_camera",
+        offset=TiledCameraCfg.OffsetCfg(
+            pos=(0.0, 0.0, 0.12),
+            rot=(0.0, 0.7071068, 0.7071068, 0.0),  # looking forward (wxyz)
+            convention="ros",
+        ),
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=36.5,
+            focus_distance=400.0,
+            horizontal_aperture=36.83,
+            clipping_range=(0.01, 50.0),
+            lock_camera=True,
+        ),
+        width=640,
+        height=480,
+        update_period=1 / 30.0,
+    )
+
+    # External front camera fixed in the scene
+    front: TiledCameraCfg = TiledCameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/elfin_base/front_camera",
+        offset=TiledCameraCfg.OffsetCfg(
+            pos=(0.0, -0.5, 0.6),
+            rot=(0.1650476, -0.9862856, 0.0, 0.0),
+            convention="ros",
+        ),
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=28.7,
+            focus_distance=400.0,
+            horizontal_aperture=38.11,
+            clipping_range=(0.01, 50.0),
+            lock_camera=True,
+        ),
+        width=640,
+        height=480,
+        update_period=1 / 30.0,
+    )
+
+    light = AssetBaseCfg(
+        prim_path="{ENV_REGEX_NS}/Light",
+        spawn=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+    )
+
+
+@configclass
+class S30EventCfg(SingleArmEventCfg):
+    """Events for S30: extends base events with Robotiq mimic-joint tracking.
+
+    track_mimic runs every physics step (interval, step=1) to drive mimic joints
+    proportional to finger_joint, replacing the ActionGraph that was removed.
+    """
+
+    track_mimic = EventTerm(
+        func=s30_mdp.track_robotiq_mimic_joints,
+        mode="interval",
+        interval_range_s=(0.0, 0.0),  # every step
+    )
+
+
+@configclass
+class S30ObservationsCfg(SingleArmObservationsCfg):
+    pass
+
+
+@configclass
+class S30TerminationsCfg(SingleArmTerminationsCfg):
+
+    success = DoneTerm(
+        func=s30_mdp.task_done,
+        params={
+            "oranges_cfg": [SceneEntityCfg("Orange001"), SceneEntityCfg("Orange002"), SceneEntityCfg("Orange003")],
+            "plate_cfg": SceneEntityCfg("Plate"),
+        },
+    )
+
+
+@configclass
+class S30PickOrangeEnvCfg(SingleArmTaskEnvCfg):
+    """Pick-orange task environment for Elfin S30 + Robotiq 2F-140."""
+
+    scene: S30TaskSceneCfg = S30TaskSceneCfg(env_spacing=8.0)
+    observations: S30ObservationsCfg = S30ObservationsCfg()
+    events: S30EventCfg = S30EventCfg()
+    terminations: S30TerminationsCfg = S30TerminationsCfg()
+
+    task_description: str = "Pick three oranges and put them into the plate, then reset the arm to rest state."
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        # Override robot name and joint feature names for S30
+        self.robot_name = "elfin_s30"
+        self.default_feature_joint_names = [f"{j}.pos" for j in S30_JOINT_NAMES]
+
+        parse_usd_and_create_subassets(
+            KITCHEN_WITH_ORANGE_USD_PATH,
+            self,
+            specific_name_list=["Orange001", "Orange002", "Orange003", "Plate"],
+        )
+
+        domain_randomization(
+            self,
+            random_options=[
+                randomize_object_uniform("Orange001", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+                randomize_object_uniform("Orange002", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+                randomize_object_uniform("Orange003", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+                randomize_object_uniform("Plate", pose_range={"x": (-0.03, 0.03), "y": (-0.03, 0.03), "z": (0.0, 0.0)}),
+                randomize_camera_uniform(
+                    "front",
+                    pose_range={
+                        "x": (-0.025, 0.025),
+                        "y": (-0.025, 0.025),
+                        "z": (-0.025, 0.025),
+                        "roll":  (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180),
+                        "pitch": (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180),
+                        "yaw":   (-2.5 * torch.pi / 180, 2.5 * torch.pi / 180),
+                    },
+                    convention="ros",
+                ),
+            ],
+        )
+
+    def build_lerobot_frame(self, episode_data: EpisodeData, dataset_cfg: LeRobotDatasetCfg) -> dict:
+        obs_data = episode_data._data["obs"]
+        action = episode_data._data["actions"][-1]
+
+        if dataset_cfg.action_align:
+            processed_action = convert_s30_action_to_lerobot(action.unsqueeze(0)).squeeze(0)
+        else:
+            processed_action = action.cpu().numpy()
+
+        frame = {
+            "action": processed_action,
+            "observation.state": convert_s30_action_to_lerobot(obs_data["joint_pos"][-1].unsqueeze(0)).squeeze(0),
+            "task": self.task_description,
+        }
+        for frame_key in dataset_cfg.features.keys():
+            if not frame_key.startswith("observation.images"):
+                continue
+            camera_key = frame_key.split(".")[-1]
+            frame[frame_key] = obs_data[camera_key][-1].cpu().numpy()
+
+        return frame

--- a/source/leisaac/leisaac/tasks/template/__init__.py
+++ b/source/leisaac/leisaac/tasks/template/__init__.py
@@ -16,6 +16,7 @@ from .lekiwi_env_cfg import (
     LeKiwiTerminationsCfg,
 )
 from .single_arm_env_cfg import (
+    SingleArmEventCfg,
     SingleArmObservationsCfg,
     SingleArmTaskEnvCfg,
     SingleArmTaskSceneCfg,

--- a/source/leisaac/leisaac/tasks/template/single_arm_env_cfg.py
+++ b/source/leisaac/leisaac/tasks/template/single_arm_env_cfg.py
@@ -194,7 +194,7 @@ class SingleArmTaskEnvCfg(ManagerBasedRLEnvCfg):
     def use_teleop_device(self, teleop_device) -> None:
         self.task_type = teleop_device
         self.actions = init_action_cfg(self.actions, device=teleop_device)
-        if teleop_device in ["keyboard", "gamepad", "so101_state_machine"]:
+        if teleop_device in ["keyboard", "gamepad", "so101_state_machine", "s30-keyboard", "s30-gamepad"]:
             self.scene.robot.spawn.rigid_props.disable_gravity = True
 
     def preprocess_device_action(self, action: dict[str, Any], teleop_device) -> torch.Tensor:

--- a/source/leisaac/leisaac/utils/constant.py
+++ b/source/leisaac/leisaac/utils/constant.py
@@ -25,6 +25,9 @@ def _resolve_assets_root() -> str:
 ASSETS_ROOT = _resolve_assets_root()
 
 SINGLE_ARM_JOINT_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+
+# Elfin S30 + Robotiq 2F-140: 6 arm joints + 1 gripper main joint
+S30_JOINT_NAMES = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "finger_joint"]
 BI_ARM_JOINT_NAMES = [
     "left_shoulder_pan",
     "left_shoulder_lift",

--- a/source/leisaac/leisaac/utils/env_utils.py
+++ b/source/leisaac/leisaac/utils/env_utils.py
@@ -60,6 +60,8 @@ def get_task_type(task: str, task_type: str | None = None) -> str:
         return "bi-so101leader"
     elif "LeKiwi" in task:
         return "lekiwi-leader"
+    elif "S30" in task:
+        return "s30"
     else:
         return "so101leader"
 

--- a/source/leisaac/leisaac/utils/monkey_patch.py
+++ b/source/leisaac/leisaac/utils/monkey_patch.py
@@ -14,6 +14,13 @@ def patch_termination_manager():
     """
     import torch
     from isaaclab.managers import TerminationManager
+    import inspect
+
+    # Check if _term_dones is already dict-based (fix already applied in this IsaacLab version)
+    source = inspect.getsource(TerminationManager.compute)
+    if "_term_dones[name]" in source:
+        # IsaacLab already contains the fix, skip patching
+        return
 
     def compute(self) -> torch.Tensor:
         # reset computation

--- a/source/leisaac/leisaac/utils/robot_utils.py
+++ b/source/leisaac/leisaac/utils/robot_utils.py
@@ -4,6 +4,11 @@ import numpy as np
 import torch
 from isaaclab.envs import DirectRLEnv, ManagerBasedEnv
 from isaaclab.sensors import Camera
+from leisaac.assets.robots.elfin_s30 import (
+    S30_MOTOR_LIMITS,
+    S30_REST_POSE_RANGE,
+    S30_USD_JOINT_LIMITS,
+)
 from leisaac.assets.robots.lerobot import (
     SO101_FOLLOWER_MOTOR_LIMITS,
     SO101_FOLLOWER_REST_POSE_RANGE,
@@ -136,6 +141,63 @@ def convert_lerobot_action_to_leisaac(action: torch.Tensor | np.ndarray) -> np.n
         processed_degree = motor_degree / motor_range * joint_range + joint_limit_range[0]
         processed_radius = processed_degree / 180.0 * torch.pi  # convert to radian
         processed_action[:, idx] = processed_radius
+
+    return processed_action
+
+
+def is_s30_at_rest_pose(joint_pos: torch.Tensor, joint_names: list[str]) -> torch.Tensor:
+    """Check if the S30 arm is in the rest pose."""
+    is_reset = torch.ones(joint_pos.shape[0], dtype=torch.bool, device=joint_pos.device)
+    joint_pos_deg = joint_pos / torch.pi * 180.0
+    for joint_name, (min_pos, max_pos) in S30_REST_POSE_RANGE.items():
+        joint_idx = joint_names.index(joint_name)
+        is_reset = torch.logical_and(
+            is_reset,
+            torch.logical_and(joint_pos_deg[:, joint_idx] > min_pos, joint_pos_deg[:, joint_idx] < max_pos),
+        )
+    return is_reset
+
+
+def convert_s30_action_to_lerobot(action: torch.Tensor | np.ndarray) -> np.ndarray:
+    """Convert joint positions from Isaac Sim (radians) to LeRobot dataset format (degrees).
+
+    For S30 the TCP/IP SDK accepts joint angles in degrees, so the dataset stores degrees.
+    Mapping: Isaac Sim radians → degrees via USD joint limits → motor limits (SDK degrees).
+    """
+    if isinstance(action, torch.Tensor):
+        action = action.cpu().numpy()
+
+    action_deg = action / np.pi * 180.0  # radians → degrees
+
+    processed_action = np.zeros_like(action_deg)
+    for idx, joint_name in enumerate(S30_USD_JOINT_LIMITS):
+        usd_min, usd_max = S30_USD_JOINT_LIMITS[joint_name]
+        mot_min, mot_max = S30_MOTOR_LIMITS[joint_name]
+        usd_range = usd_max - usd_min
+        mot_range = mot_max - mot_min
+        joint_deg = action_deg[:, idx] - usd_min
+        processed_action[:, idx] = joint_deg / usd_range * mot_range + mot_min
+
+    return processed_action
+
+
+def convert_lerobot_action_to_s30(action: torch.Tensor | np.ndarray) -> np.ndarray:
+    """Convert joint positions from LeRobot dataset format (degrees) to Isaac Sim (radians).
+
+    Inverse of convert_s30_action_to_lerobot.
+    """
+    if isinstance(action, torch.Tensor):
+        action = action.cpu().numpy()
+
+    processed_action = np.zeros_like(action)
+    for idx, joint_name in enumerate(S30_USD_JOINT_LIMITS):
+        usd_min, usd_max = S30_USD_JOINT_LIMITS[joint_name]
+        mot_min, mot_max = S30_MOTOR_LIMITS[joint_name]
+        usd_range = usd_max - usd_min
+        mot_range = mot_max - mot_min
+        motor_deg = action[:, idx] - mot_min
+        deg = motor_deg / mot_range * usd_range + usd_min
+        processed_action[:, idx] = deg / 180.0 * np.pi  # degrees → radians
 
     return processed_action
 


### PR DESCRIPTION
Add full support for the Elfin S30 6-DOF arm with Robotiq 2F-140 gripper as a new robot platform in LeIsaac alongside the existing SO101 follower.

New files:
- source/leisaac/leisaac/assets/robots/elfin_s30.py ArticulationCfg for S30 arm + Robotiq gripper with correct actuator parameters (stiffness=349/800, damping=34.9/40).
- source/leisaac/leisaac/devices/keyboard/s30_keyboard.py S30-specific keyboard teleoperation device using DiffIK on elfin_link6.
- source/leisaac/leisaac/tasks/s30_pick_orange/ New pick-orange task for S30: environment config, MDP events/terminations, gym registration (LeIsaac-S30-PickOrange-v0).

Key changes to existing files:
- devices/action_process.py: add s30 / s30-keyboard / s30-gamepad branches.
- scripts/teleoperation/teleop_se3_agent.py: add s30-keyboard device choice.
- utils/robot_utils.py: S30 action ↔ LeRobot conversion functions.
- utils/constant.py: add S30_JOINT_NAMES.
- utils/env_utils.py: return "s30" task type for S30 tasks.
- policy/service_policy_clients.py: S30 observation/action handling.
- policy/lerobot/helpers.py + __init__.py: fix async_inference helpers path.
- tasks/template: export SingleArmEventCfg; enable gravity-disable for S30.
- utils/monkey_patch.py: guard against double-patching TerminationManager.

Gripper control (replaces ActionGraph removed for GPU-physics compatibility):
- Robotiq_2F_140_controller.usd emptied to remove ActionGraph which caused PxArticulationJointReducedCoordinate::setDriveTarget GPU-mode errors.
- Python EventTerm (track_robotiq_mimic_joints) runs every step to mirror right_outer_knuckle_joint (+1) and left/right_inner_finger_pad_joint (-1) from finger_joint, matching the original ActionGraph behaviour exactly.
- All 4-bar linkage joints (inner_knuckle, outer_finger, inner_finger) rely on PhysX gear constraints already defined in physics_edit.usd.

Made-with: Cursor